### PR TITLE
Allow statically linked binaries in the bundle

### DIFF
--- a/src/oui_lib/ldd.ml
+++ b/src/oui_lib/ldd.ml
@@ -36,9 +36,16 @@ let is_elf file =
   close_in ic;
   is_elf
 
+let is_dynamic path =
+  match System.call File path with
+  | line :: _ ->
+    let r = Re.Str.regexp {|.*dynamically linked.*|} in
+    Re.Str.string_match r line 0
+  | _ -> false
+
 let get_sos binary =
   let path = OpamFilename.to_string binary in
-  if is_elf path then
+  if is_elf path && is_dynamic path then
     let output = System.call Ldd path in
     let shared_libs = List.filter_map parse_true_so_line output in
     let to_embed = List.filter should_embed shared_libs in

--- a/src/oui_lib/system.ml
+++ b/src/oui_lib/system.ml
@@ -80,6 +80,7 @@ type _ command =
   | Productbuild : productbuild_args command
   | Patchelf : patchelf_args command
   | Touch : touch_args command
+  | File : string command
 
 exception System_error of string
 
@@ -160,6 +161,8 @@ let call_inner : type a. a command -> a -> string * string list =
     "patchelf", ["--set-rpath"; rpath; OpamFilename.to_string binary]
   | Touch, { mtime; file } ->
     "touch", [ "-t"; mtime; file ]
+  | File, path ->
+    "file", [ path ]
 
 let gen_command_tmp_dir cmd =
   Printf.sprintf "%s-%06x" (Filename.basename cmd) (Random.int 0xFFFFFF)

--- a/src/oui_lib/system.mli
+++ b/src/oui_lib/system.mli
@@ -101,6 +101,7 @@ type _ command =
   | Productbuild : productbuild_args command (** {b productbuild} command to create macOS installer packages *)
   | Patchelf : patchelf_args command
   | Touch : touch_args command (** {b touch} command to change files timestamps *)
+  | File : string command (* {b file} command to check if the binay is dynamically linked *)
 
 (** Calls given command with its arguments and parses output, line by line. Raises [System_error]
     with command's output when command exits with non-zero exit status. *)


### PR DESCRIPTION
The `ldd` command returns a nonzero code if the binary is not dynamically linked. We must check that the binary is dynamically linked before calling `ldd` on it.