### PR TITLE
Filter out libpthread and libdl, they are closely related to libc

### DIFF
--- a/src/oui_lib/ldd.ml
+++ b/src/oui_lib/ldd.ml
@@ -19,7 +19,9 @@ let should_embed (name, _) =
      configurable by the user. *)
   match String.split_on_char '.' name with
   | "libc"::_
-  | "libm"::_ -> false
+  | "libm"::_
+  | "libpthread"::_
+  | "libdl"::_ -> false
   | _ -> true
 
 let elf_magic_number = "\x7FELF"


### PR DESCRIPTION
Basically libc, libpthread and libdl need to be synchronised (second post here: https://groups.google.com/g/uk.comp.os.linux/c/PX3rstGtZRQ). 