### PR TITLE
Provide a way to generate desktop files during installation

### DIFF
--- a/src/oui_lib/installer_config.ml
+++ b/src/oui_lib/installer_config.ml
@@ -14,6 +14,7 @@ type exec_file = {
     path : string;
     symlink : bool; [@default true]
     deps : bool; [@default true]
+    desktop_tpl: string option; [@default None]
   }
 [@@deriving yojson {meta = true}]
 
@@ -25,7 +26,8 @@ let exec_file_to_yojson exec_file =
 
 let exec_file_of_yojson : Yojson.Safe.t -> (exec_file, string) result =
   function
-  | `String path -> Ok ({ path; symlink = true; deps = true})
+  | `String path ->
+    Ok ({ path; symlink = true; deps = true; desktop_tpl = None})
   | `Assoc _ as json ->
     let open Letop.Result in
     let* exec_file = [%of_yojson: exec_file] json in

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -12,6 +12,7 @@ type exec_file = {
     path : string;
     symlink : bool; [@default true]
     deps : bool; [@default true]
+    desktop_tpl: string option; [@default None]
   }
 
 type man_section =
@@ -113,4 +114,3 @@ val manpages_of_expanded : expanded_manpages -> manpages
 
 val load : OpamFilename.t -> (user, [> `Invalid_config of string]) result
 val save : user -> OpamFilename.t -> unit
-

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -34,6 +34,8 @@ let mandir_nv = "MANDIR"
 let mandir_v = !$ mandir_nv
 let bindir_nv = "BINDIR"
 let bindir_v = !$ bindir_nv
+let appdir_nv = "APPDIR"
+let appdir_v = !$ appdir_nv
 
 let opt = "/opt"
 
@@ -41,6 +43,8 @@ module Global = struct
   let pre = "/usr/local"
   let bin = pre / "bin"
   let shareman = pre / "share/man"
+  let shareapplications = pre / "share/applications"
+  let localshareapplications = pre / "local/share/applications"
   let man = pre / "man"
 end
 
@@ -48,6 +52,7 @@ module User = struct
   let pre = "$HOME/.local"
   let bin = pre / "bin"
   let man = pre / "man"
+  let applications = pre / "share/applications"
 end
 
 let install_conf = "install.conf"
@@ -133,6 +138,10 @@ let list_all_files ~install_dir ~bindir ~mandir
     (fun (x : Installer_config.exec_file) ->
        bindir / (Filename.basename x.path))
     ic.exec_files
+  @ List.filter_map
+    (fun (x : Installer_config.exec_file) ->
+       Option.map (fun x -> appdir_v / (Filename.basename x)) x.desktop_tpl)
+    ic.exec_files
   @ List.concat_map
     (fun (section, files) ->
        let dir = mandir / section in
@@ -151,6 +160,7 @@ let set_user_prefixes =
   let open Sh_script in
   [ assign ~var:bindir_nv ~value:User.bin
   ; assign ~var:mandir_nv ~value:User.man
+  ; assign ~var:appdir_nv ~value:User.applications
   ]
 
 (* checks whether this is a user or global install based on the
@@ -202,9 +212,19 @@ let set_default_mandir =
       ()
   ]
 
+let set_default_appdir =
+  let open Sh_script in
+  [ if_ (Dir_exists Global.shareapplications)
+      [assign ~var:appdir_nv ~value:Global.shareapplications]
+      ~else_:[assign ~var:appdir_nv ~value:Global.localshareapplications]
+      ()
+  ]
+
 let set_root_prefixes =
   let open Sh_script in
-  assign ~var:bindir_nv ~value:Global.bin :: set_default_mandir
+  assign ~var:bindir_nv ~value:Global.bin
+  :: set_default_mandir
+  @ set_default_appdir
 
 let add_symlink ~install_dir ~in_ bundle_path =
   let open Sh_script in
@@ -511,7 +531,7 @@ let install_script ~installer_name (ic : Installer_config.internal) =
     @ warn_if_existing
     @ prompt_for_confirmation
     @ remove_existing
-    :: create_install_dir
+      :: create_install_dir
   in
   let install_bundle =
     Sh_script.copy_all_in ~src:"." ~dst:install_dir ~except:install_script_name
@@ -533,6 +553,44 @@ let install_script ~installer_name (ic : Installer_config.internal) =
         "If you want to safely uninstall %s, please run %s/%s."
         package install_dir uninstall_script_name
     ]
+  in
+  let make_desktop_files =
+    let create_applications_dir =
+      [
+        create_if_not_found appdir_v;
+        mkdir ~permissions:755 [appdir_v];
+      ]
+    in
+    let create_desktop_file file =
+      let base_desktop_file = Filename.basename file in
+      let install_pattern = "%{install_path}" in
+      let installed = appdir_v / base_desktop_file in
+      Sh_script.[
+        Cp { src = file ; dst = installed } ;
+        Chmod { permissions = 644 ; files = [ installed ] } ;
+        Sed {
+          file = installed ;
+          pattern = install_pattern ; value = install_path_v
+        } ;
+        if_ Is_not_root [
+          write_file ~append:true installed
+          [ "NoDisplay=true" ]
+        ] () ;
+        echof "Adding %s to %s" base_desktop_file appdir_v
+      ]
+    in
+    let files =
+      List.fold_left
+        begin fun acc exec_file ->
+          match exec_file.Installer_config.desktop_tpl with
+          | None -> acc
+          | Some file -> (create_desktop_file file) @ acc
+        end
+        [] ic.exec_files
+    in
+    match files with
+    | [] -> []
+    | files -> create_applications_dir @ files
   in
   let install_plugins = List.concat_map (install_plugin ~install_dir) ic.plugins in
   let dump_install_conf =
@@ -572,6 +630,7 @@ let install_script ~installer_name (ic : Installer_config.internal) =
   @ install_binaries
   @ install_manpages
   @ install_plugins
+  @ make_desktop_files
   @ notify_install_complete
 
 let display_plugin (plugin : Installer_config.plugin) =
@@ -616,6 +675,16 @@ let uninstall_script (ic : Installer_config.internal) =
       )
       binaries
   in
+  let display_desktop_files =
+    let out_file file =
+      Sh_script.echof "- %s" (appdir_v / Filename.basename file)
+    in
+    List.filter_map
+      begin fun Installer_config.{ desktop_tpl  ; _} ->
+        Option.map out_file desktop_tpl
+      end
+      ic.exec_files
+  in
   let manpages = Option.value ic.manpages ~default:[] in
   let display_manpages =
     List.concat_map
@@ -651,6 +720,7 @@ let uninstall_script (ic : Installer_config.internal) =
     @ display_symlinks
     @ display_manpages
     @ display_plugins
+    @ display_desktop_files
   in
   let check_permissions =
     [ if_ Is_not_root
@@ -688,6 +758,19 @@ let uninstall_script (ic : Installer_config.internal) =
            pages)
       manpages
   in
+  let remove_desktop_files =
+    let out_file file = appdir_v / Filename.basename file in
+    let files =
+      List.filter_map
+        begin fun Installer_config.{ desktop_tpl  ; _} ->
+          Option.map out_file desktop_tpl
+        end
+        ic.exec_files
+    in
+    match files with
+    | [] -> []
+    | files -> [Sh_script.Rm { files ; rec_ = false}]
+  in
   let remove_plugins = List.concat_map uninstall_plugin ic.plugins in
   let notify_uninstall_complete = [echof "Uninstallation complete!"] in
   setup
@@ -697,6 +780,7 @@ let uninstall_script (ic : Installer_config.internal) =
   @ remove_symlinks
   @ remove_manpages
   @ remove_plugins
+  @ remove_desktop_files
   @ notify_uninstall_complete
 
 let add_sos_to_bundle ~bundle_dir (binary : Installer_config.exec_file) =

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -43,8 +43,8 @@ module Global = struct
   let pre = "/usr/local"
   let bin = pre / "bin"
   let shareman = pre / "share/man"
-  let shareapplications = pre / "share/applications"
-  let localshareapplications = pre / "local/share/applications"
+  let shareapplications = "/usr/share/applications"
+  let localshareapplications = pre / "share/applications"
   let man = pre / "man"
 end
 

--- a/src/oui_lib/opam_frontend.ml
+++ b/src/oui_lib/opam_frontend.ml
@@ -363,7 +363,11 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
   let name = OpamPackage.Name.to_string (OpamPackage.name package) in
   let exec_files =
     List.map (fun x ->
-        { path = OpamFilename.Base.to_string x; symlink = true; deps = true }
+        { path = OpamFilename.Base.to_string x;
+          symlink = true;
+          deps = true;
+          desktop_tpl = None;
+        }
       ) exe_bases
   in
   let wix_manufacturer = String.concat ", " (OpamFile.OPAM.maintainer opam) in

--- a/src/oui_lib/sh_script.ml
+++ b/src/oui_lib/sh_script.ml
@@ -18,8 +18,8 @@ type numerical_op =
   | Eq
 
 type string_op =
- | Not_empty of string
- | Equal of string * string
+  | Not_empty of string
+  | Equal of string * string
 
 type condition =
   | Exists of string
@@ -66,6 +66,7 @@ type command =
   | Read_file of {file: string; line_var: string; process_line: command list}
   | Def_fun of {name: string; body : command list}
   | Call_fun of {name: string; args: string list}
+  | Sed of {file: string; pattern: string; value: string}
 and case =
   { pattern : string
   ; commands : command list
@@ -228,6 +229,8 @@ let rec pp_sh_command ?(newline=true) ~indent fmtr command =
     fpf "%s" name
   | Call_fun {name; args} ->
     fpf "%s %s" name (String.concat " " args)
+  | Sed {file; pattern; value} ->
+    fpf "sed -i 's,%s,'\"%s\"',' %s" pattern value file
 
 and pp_sh_case ~indent fmtr {pattern; commands} =
   let indent_str = String.make indent ' ' in

--- a/src/oui_lib/sh_script.mli
+++ b/src/oui_lib/sh_script.mli
@@ -66,6 +66,7 @@ type command =
   | Read_file of {file: string; line_var: string; process_line: command list}
   | Def_fun of {name: string; body : command list}
   | Call_fun of {name: string; args: string list}
+  | Sed of {file: string; pattern: string; value: string}
 and case =
   { pattern : string
   ; commands : command list

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -73,8 +73,14 @@ let%expect_test "install_script: simple" =
   in
   let config =
     make_config ~name:"aaa" ~version:"x.y.z"
-      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
-                   { path = "aaa-utility"; symlink = true; deps = true } ]
+      ~exec_files:[
+        { path = "aaa-command"
+        ; symlink = true
+        ; deps = true
+        ; desktop_tpl = Some "file.desktop"
+        };
+        { path = "aaa-utility"; symlink = true; deps = true ; desktop_tpl = None }
+      ]
       ~manpages
       ()
   in
@@ -111,6 +117,11 @@ let%expect_test "install_script: simple" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -158,6 +169,7 @@ let%expect_test "install_script: simple" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -178,6 +190,7 @@ let%expect_test "install_script: simple" =
     echo "- $PREFIX/aaa"
     echo "- $BINDIR/aaa-command"
     echo "- $BINDIR/aaa-utility"
+    echo "- $APPDIR/file.desktop"
     echo "- $MANDIR/man1/aaa-command.1"
     echo "- $MANDIR/man1/aaa-utility.1"
     echo "- $MANDIR/man5/aaa-file.1"
@@ -185,6 +198,7 @@ let%expect_test "install_script: simple" =
     collect_existing "$PREFIX/aaa"
     collect_existing "$BINDIR/aaa-command"
     collect_existing "$BINDIR/aaa-utility"
+    collect_existing "$APPDIR/file.desktop"
     collect_existing "$MANDIR/man1/aaa-command.1"
     collect_existing "$MANDIR/man1/aaa-utility.1"
     collect_existing "$MANDIR/man5/aaa-file.1"
@@ -231,6 +245,19 @@ let%expect_test "install_script: simple" =
     ln -s "$PREFIX/aaa/man/man1/aaa-utility.1" "$MANDIR/man1/aaa-utility.1"
     mkdir -p -m 755 "$MANDIR/man5"
     ln -s "$PREFIX/aaa/man/man5/aaa-file.1" "$MANDIR/man5/aaa-file.1"
+    if ! [ -d "$APPDIR" ]; then
+      mkdir -p -m 755 "$APPDIR"
+    fi
+    mkdir -p -m 755 "$APPDIR"
+    cp file.desktop $APPDIR/file.desktop
+    chmod 644 "$APPDIR/file.desktop"
+    sed -i 's,%{install_path},'"$INSTALL_PATH"',' $APPDIR/file.desktop
+    if [ "$(id -u)" -ne 0 ]; then
+      {
+        printf '%s\n' "NoDisplay=true"
+      } >> "$APPDIR/file.desktop"
+    fi
+    echo "Adding file.desktop to $APPDIR"
     echo "Installation complete!"
     echo "If you want to safely uninstall aaa, please run $PREFIX/aaa/uninstall.sh."
     |}]
@@ -273,6 +300,11 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -320,6 +352,7 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -462,6 +495,11 @@ let%expect_test "install_script: install plugins" =
     else
       MANDIR="/usr/local/man"
     fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
+    fi
     while [ $# -gt 0 ]; do
       case "$1" in
         --prefix)
@@ -508,6 +546,7 @@ let%expect_test "install_script: install plugins" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -667,12 +706,18 @@ let%expect_test "uninstall_script: uninstall plugins" =
     if [ "$IS_USER_INSTALL" = "true" ]; then
       BINDIR="$HOME/.local/bin"
       MANDIR="$HOME/.local/man"
+      APPDIR="$HOME/.local/share/applications"
     else
       BINDIR="/usr/local/bin"
       if [ -d "/usr/local/share/man" ]; then
         MANDIR="/usr/local/share/man"
       else
         MANDIR="/usr/local/man"
+      fi
+      if [ -d "/usr/local/share/applications" ]; then
+        APPDIR="/usr/local/share/applications"
+      else
+        APPDIR="/usr/local/local/share/applications"
       fi
     fi
     echo "About to uninstall t-name."
@@ -740,8 +785,10 @@ let%expect_test "uninstall_script: simple" =
   in
   let config =
     make_config ~name:"aaa"
-      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
-                   { path = "aaa-utility"; symlink = true; deps = true } ]
+      ~exec_files:[
+        { path = "aaa-command"; symlink = true; deps = true ; desktop_tpl = None };
+        { path = "aaa-utility"; symlink = true; deps = true ; desktop_tpl = None }
+      ]
       ~manpages
       ()
   in
@@ -787,12 +834,18 @@ let%expect_test "uninstall_script: simple" =
     if [ "$IS_USER_INSTALL" = "true" ]; then
       BINDIR="$HOME/.local/bin"
       MANDIR="$HOME/.local/man"
+      APPDIR="$HOME/.local/share/applications"
     else
       BINDIR="/usr/local/bin"
       if [ -d "/usr/local/share/man" ]; then
         MANDIR="/usr/local/share/man"
       else
         MANDIR="/usr/local/man"
+      fi
+      if [ -d "/usr/local/share/applications" ]; then
+        APPDIR="/usr/local/share/applications"
+      else
+        APPDIR="/usr/local/local/share/applications"
       fi
     fi
     echo "About to uninstall aaa."
@@ -849,7 +902,11 @@ let%expect_test "uninstall_script: simple" =
 (* Regression test that ensures that if the binaries are not at the bundle's
    root, the symlink are still installed correctly. *)
 let%expect_test "install_script: binary in sub folder" =
-  let config = make_config ~exec_files:[{ path = "bin/do"; symlink = true; deps = true }] () in
+  let config = make_config
+      ~exec_files:[
+        { path = "bin/do"; symlink = true; deps = true; desktop_tpl = None }
+      ] ()
+  in
   let installer_name = "installer.run" in
   let install_script = Makeself_backend.install_script ~installer_name config in
   Format.printf "%a" pp_sh install_script;
@@ -883,6 +940,11 @@ let%expect_test "install_script: binary in sub folder" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -930,6 +992,7 @@ let%expect_test "install_script: binary in sub folder" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -994,7 +1057,10 @@ let%expect_test "install_script: binary in sub folder" =
 (* Regression test that ensures that if the binaries are not at the bundle's
    root, the symlinks are correctly removed by the uninstall script. *)
 let%expect_test "uninstall_script: binary in sub folder" =
-  let config = make_config ~exec_files:[{ path = "bin/do"; symlink = true; deps = true }] () in
+  let config = make_config ~exec_files:[
+      { path = "bin/do"; symlink = true; deps = true ; desktop_tpl = None }
+    ] ()
+  in
   let uninstall_script = Makeself_backend.uninstall_script config in
   Format.printf "%a" pp_sh uninstall_script;
   [%expect {|
@@ -1037,12 +1103,18 @@ let%expect_test "uninstall_script: binary in sub folder" =
     if [ "$IS_USER_INSTALL" = "true" ]; then
       BINDIR="$HOME/.local/bin"
       MANDIR="$HOME/.local/man"
+      APPDIR="$HOME/.local/share/applications"
     else
       BINDIR="/usr/local/bin"
       if [ -d "/usr/local/share/man" ]; then
         MANDIR="/usr/local/share/man"
       else
         MANDIR="/usr/local/man"
+      fi
+      if [ -d "/usr/local/share/applications" ]; then
+        APPDIR="/usr/local/share/applications"
+      else
+        APPDIR="/usr/local/local/share/applications"
       fi
     fi
     echo "About to uninstall test-name."
@@ -1079,7 +1151,9 @@ let%expect_test "uninstall_script: binary in sub folder" =
 let%expect_test "install_script: set environment for binaries" =
   let config =
     make_config
-      ~exec_files:[{ path = "bin/app"; symlink = true; deps = true }]
+      ~exec_files:[
+        { path = "bin/app"; symlink = true; deps = true; desktop_tpl = None }
+      ]
       ~environment:[("VAR1", "value1"); ("VAR2", "$INSTALL_PATH/lib")]
       ()
   in
@@ -1116,6 +1190,11 @@ let%expect_test "install_script: set environment for binaries" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -1163,6 +1242,7 @@ let%expect_test "install_script: set environment for binaries" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -118,10 +118,10 @@ let%expect_test "install_script: simple" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -301,10 +301,10 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -495,10 +495,10 @@ let%expect_test "install_script: install plugins" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -714,10 +714,10 @@ let%expect_test "uninstall_script: uninstall plugins" =
       else
         MANDIR="/usr/local/man"
       fi
-      if [ -d "/usr/local/share/applications" ]; then
-        APPDIR="/usr/local/share/applications"
+      if [ -d "/usr/share/applications" ]; then
+        APPDIR="/usr/share/applications"
       else
-        APPDIR="/usr/local/local/share/applications"
+        APPDIR="/usr/local/share/applications"
       fi
     fi
     echo "About to uninstall t-name."
@@ -842,10 +842,10 @@ let%expect_test "uninstall_script: simple" =
       else
         MANDIR="/usr/local/man"
       fi
-      if [ -d "/usr/local/share/applications" ]; then
-        APPDIR="/usr/local/share/applications"
+      if [ -d "/usr/share/applications" ]; then
+        APPDIR="/usr/share/applications"
       else
-        APPDIR="/usr/local/local/share/applications"
+        APPDIR="/usr/local/share/applications"
       fi
     fi
     echo "About to uninstall aaa."
@@ -941,10 +941,10 @@ let%expect_test "install_script: binary in sub folder" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -1111,10 +1111,10 @@ let%expect_test "uninstall_script: binary in sub folder" =
       else
         MANDIR="/usr/local/man"
       fi
-      if [ -d "/usr/local/share/applications" ]; then
-        APPDIR="/usr/local/share/applications"
+      if [ -d "/usr/share/applications" ]; then
+        APPDIR="/usr/share/applications"
       else
-        APPDIR="/usr/local/local/share/applications"
+        APPDIR="/usr/local/share/applications"
       fi
     fi
     echo "About to uninstall test-name."
@@ -1191,10 +1191,10 @@ let%expect_test "install_script: set environment for binaries" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in


### PR DESCRIPTION
The input file can contain the string `%{install_path}` which is automatically replaced during installation.