### PR TITLE
Filter out libpthread and libdl, they are closely related to libc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 - Fix detection of pre-existing files on Linux. (#128, @NathanReb)
 - Fix a bug where passing a directory with a trailing `/` would cause the
   install to fail. (#128, @NathanReb)
+- Fix a bug where `oui` would embed unwanted shared libraries on Linux.
+  (#138, @AllanBlanchard)
 
 ### Removed
 

--- a/src/oui_lib/ldd.ml
+++ b/src/oui_lib/ldd.ml
@@ -19,7 +19,9 @@ let should_embed (name, _) =
      configurable by the user. *)
   match String.split_on_char '.' name with
   | "libc"::_
-  | "libm"::_ -> false
+  | "libm"::_
+  | "libpthread"::_
+  | "libdl"::_ -> false
   | _ -> true
 
 let elf_magic_number = "\x7FELF"

--- a/tests/oui_lib/test_ldd.ml
+++ b/tests/oui_lib/test_ldd.ml
@@ -38,26 +38,27 @@ let%expect_test "parse_true_so_line: regular .so" =
 
 (* [should_embed] *)
 
-let%expect_test "should_embed: libc" =
-  let lib =
-    ("libc.so.6", OpamFilename.of_string "/lib/x86_64-linux-gnu/libc.so.6")
-  in
+let test_should_embed lib file =
+  let lib = (lib, OpamFilename.of_string file) in
   let result = Ldd.should_embed lib in
-  Format.printf "%b" result;
+  Format.printf "%b" result
+
+let%expect_test "should_embed: libc" =
+  test_should_embed "libc.so.6" "/lib/x86_64-linux-gnu/libc.so.6";
   [%expect {| false |}]
 
 let%expect_test "should_embed: libm" =
-  let lib =
-    ("libm.so.6", OpamFilename.of_string "/lib/x86_64-linux-gnu/libm.so.6")
-  in
-  let result = Ldd.should_embed lib in
-  Format.printf "%b" result;
+  test_should_embed "libm.so.6" "/lib/x86_64-linux-gnu/libm.so.6";
+  [%expect {| false |}]
+
+let%expect_test "should_embed: libdl" =
+  test_should_embed "libdl.so.2" "/lib/x86_64-linux-gnu/libdl.so.2";
+  [%expect {| false |}]
+
+let%expect_test "should_embed: libpthread" =
+  test_should_embed "libpthread.so.0" "/lib/x86_64-linux-gnu/libpthread.so.0";
   [%expect {| false |}]
 
 let%expect_test "should_embed: somelib" =
-  let lib =
-    ("somelib.so.1", OpamFilename.of_string "/lib/x86_64-linux-gnu/somelib.so.1")
-  in
-  let result = Ldd.should_embed lib in
-  Format.printf "%b" result;
+  test_should_embed "somelib.so.1" "/lib/x86_64-linux-gnu/somelib.so.1";
   [%expect {| true |}]


### PR DESCRIPTION
Basically libc, libpthread and libdl need to be synchronised (second post here: https://groups.google.com/g/uk.comp.os.linux/c/PX3rstGtZRQ).