### PR TITLE
Blacklist more shared libraries for embedding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 - Fix a bug where passing a directory with a trailing `/` would cause the
   install to fail. (#128, @NathanReb)
 - Fix a bug where `oui` would embed unwanted shared libraries on Linux.
-  (#138, @AllanBlanchard)
+  (#138 #144, @AllanBlanchard @NathanReb)
 
 ### Removed
 

--- a/src/oui_lib/ldd.ml
+++ b/src/oui_lib/ldd.ml
@@ -16,10 +16,25 @@ let parse_true_so_line l =
 
 let should_embed (name, _) =
   (* Those are hardcoded for now but we should ultimately make this
-     configurable by the user. *)
+     configurable by the user.
+     We exclude the dynamic linker (all ld* names) and the glibc along
+     with libs that are co-developed with it and rely on GLIBC_PRIVATE symbols.
+  *)
   match String.split_on_char '.' name with
+  | "ld-linux"::_
+  | "ld-linux-x86-64"::_
+  | "ld-linux-aarch64"::_
+  | "ld-linux-armhf"::_
+  | "ld-linux-arm"::_
+  | "ld64"::_
+  | "ld-linux-riscv64-lp64d"::_
+  | "ld-musl-x86_64"::_
+  | "ld-musl-aarch64"::_
   | "libc"::_
   | "libm"::_
+  | "librt"::_
+  | "libresolv"::_
+  | "libutil"::_
   | "libpthread"::_
   | "libdl"::_ -> false
   | _ -> true

--- a/tests/oui_lib/test_ldd.ml
+++ b/tests/oui_lib/test_ldd.ml
@@ -59,6 +59,23 @@ let%expect_test "should_embed: libpthread" =
   test_should_embed "libpthread.so.0" "/lib/x86_64-linux-gnu/libpthread.so.0";
   [%expect {| false |}]
 
+let%expect_test "should_embed: dynamic linker" =
+  test_should_embed "ld-linux-x86-64.so.2"
+    "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2";
+  [%expect {| false |}]
+
+let%expect_test "should_embed: librt" =
+  test_should_embed "librt.so.1" "/lib/x86_64-linux-gnu/librt.so.1";
+  [%expect {| false |}]
+
+let%expect_test "should_embed: libresolv" =
+  test_should_embed "libresolv.so.2" "/lib/x86_64-linux-gnu/libresolv.so.2";
+  [%expect {| false |}]
+
+let%expect_test "should_embed: libutil" =
+  test_should_embed "libutil.so.1" "/lib/x86_64-linux-gnu/libutil.so.1";
+  [%expect {| false |}]
+
 let%expect_test "should_embed: somelib" =
   test_should_embed "somelib.so.1" "/lib/x86_64-linux-gnu/somelib.so.1";
   [%expect {| true |}]


### PR DESCRIPTION
This adds a range of names for the dynamic linker which was sometime embedded by mistake and some libraries that rely on glibc private symbols: libresolv, librt, libutil.