### PR TITLE
Add support for desktop file installation on Linux

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Add support for desktop files installation on Linux (#146, @AllanBlanchard
+  @NathanReb)
+
 ### Changed
 
 - On linux, write `install.conf` earlier during install to allow recovering

--- a/doc/README.md
+++ b/doc/README.md
@@ -99,6 +99,9 @@ It contains the following fields:
   executable in `/usr/local/bin`. True by default.
 - `deps`, **boolean**, **optional**: Whether to resolve shared library
   dependencies on the executable. True by default.
+- `desktop_tpl`, **string**, **optional**: Path to a desktop file template to
+  be installed on linux. None by default. If missing, no desktop file is
+  installed. See the [Desktop files](#desktop-files) section for details.
 
 *Example:*
 ```json
@@ -437,7 +440,7 @@ In this example our main app's called `foo` and our plugin `bar`, known as
 
 #### Generating the bundle
 
-There's no specifics here and you can simply use the same commands as in the 
+There's no specifics here and you can simply use the same commands as in the
 [Generating the installation bundle](#generating-the-installation-bundle)
 section above.
 
@@ -480,7 +483,7 @@ foo-bar.bundle/
 │   ├── foo-bar
 │   │   ├── META
 │   │   └── bar.cmxs
-│   └── yojson 
+│   └── yojson
 │       ├── META
 │       └── yojson.cmxs
 └── man
@@ -556,6 +559,22 @@ as described by the plugin and the app respective `oui.json` configuration.
 An `uninstall.sh` script is also installed alongside the application
 that can be run to cleanly remove it from the system. It will remove
 the installation folder and all symlinks created during the installation.
+
+#### Desktop files
+
+By default `oui` will not install desktop files for your applications. If you'd
+like to install desktop files you can provide a template in the bundle and list
+it in the [exec_file object](#exec_files-object) of the app in your JSON config.
+
+At install time, the template will be used to generate a desktop file and
+install it in `/usr/share/applications` or `/usr/local/share/applications` for
+global installs or in `$HOME/.local/share/applications` for user installs.
+The desktop file itself will be named `<unique_id>.<exec-basename-no-extension>.desktop`.
+
+The template can use the following variables that will be substituted at install
+time:
+- `%{install_path}`: will be replace by the absolute path to the install folder
+  e.g. `/opt/alt-ergo` or `$HOME/.local/frama-c`
 
 ### Windows / WiX
 

--- a/src/oui_lib/installer_config.ml
+++ b/src/oui_lib/installer_config.ml
@@ -14,6 +14,7 @@ type exec_file = {
     path : string;
     symlink : bool; [@default true]
     deps : bool; [@default true]
+    desktop_tpl: string option; [@default None]
   }
 [@@deriving yojson {meta = true}]
 
@@ -25,7 +26,8 @@ let exec_file_to_yojson exec_file =
 
 let exec_file_of_yojson : Yojson.Safe.t -> (exec_file, string) result =
   function
-  | `String path -> Ok ({ path; symlink = true; deps = true})
+  | `String path ->
+    Ok ({ path; symlink = true; deps = true; desktop_tpl = None})
   | `Assoc _ as json ->
     let open Letop.Result in
     let* exec_file = [%of_yojson: exec_file] json in

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -12,6 +12,7 @@ type exec_file = {
     path : string;
     symlink : bool; [@default true]
     deps : bool; [@default true]
+    desktop_tpl: string option; [@default None]
   }
 
 type man_section =
@@ -113,4 +114,3 @@ val manpages_of_expanded : expanded_manpages -> manpages
 
 val load : OpamFilename.t -> (user, [> `Invalid_config of string]) result
 val save : user -> OpamFilename.t -> unit
-

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -34,6 +34,8 @@ let mandir_nv = "MANDIR"
 let mandir_v = !$ mandir_nv
 let bindir_nv = "BINDIR"
 let bindir_v = !$ bindir_nv
+let appdir_nv = "APPDIR"
+let appdir_v = !$ appdir_nv
 
 let opt = "/opt"
 
@@ -41,6 +43,8 @@ module Global = struct
   let pre = "/usr/local"
   let bin = pre / "bin"
   let shareman = pre / "share/man"
+  let shareapplications = pre / "share/applications"
+  let localshareapplications = pre / "local/share/applications"
   let man = pre / "man"
 end
 
@@ -48,6 +52,7 @@ module User = struct
   let pre = "$HOME/.local"
   let bin = pre / "bin"
   let man = pre / "man"
+  let applications = pre / "share/applications"
 end
 
 let install_conf = "install.conf"
@@ -133,6 +138,10 @@ let list_all_files ~install_dir ~bindir ~mandir
     (fun (x : Installer_config.exec_file) ->
        bindir / (Filename.basename x.path))
     ic.exec_files
+  @ List.filter_map
+    (fun (x : Installer_config.exec_file) ->
+       Option.map (fun x -> appdir_v / (Filename.basename x)) x.desktop_tpl)
+    ic.exec_files
   @ List.concat_map
     (fun (section, files) ->
        let dir = mandir / section in
@@ -151,6 +160,7 @@ let set_user_prefixes =
   let open Sh_script in
   [ assign ~var:bindir_nv ~value:User.bin
   ; assign ~var:mandir_nv ~value:User.man
+  ; assign ~var:appdir_nv ~value:User.applications
   ]
 
 (* checks whether this is a user or global install based on the
@@ -202,9 +212,19 @@ let set_default_mandir =
       ()
   ]
 
+let set_default_appdir =
+  let open Sh_script in
+  [ if_ (Dir_exists Global.shareapplications)
+      [assign ~var:appdir_nv ~value:Global.shareapplications]
+      ~else_:[assign ~var:appdir_nv ~value:Global.localshareapplications]
+      ()
+  ]
+
 let set_root_prefixes =
   let open Sh_script in
-  assign ~var:bindir_nv ~value:Global.bin :: set_default_mandir
+  assign ~var:bindir_nv ~value:Global.bin
+  :: set_default_mandir
+  @ set_default_appdir
 
 let add_symlink ~install_dir ~in_ bundle_path =
   let open Sh_script in
@@ -511,7 +531,7 @@ let install_script ~installer_name (ic : Installer_config.internal) =
     @ warn_if_existing
     @ prompt_for_confirmation
     @ remove_existing
-    :: create_install_dir
+      :: create_install_dir
   in
   let install_bundle =
     Sh_script.copy_all_in ~src:"." ~dst:install_dir ~except:install_script_name
@@ -533,6 +553,44 @@ let install_script ~installer_name (ic : Installer_config.internal) =
         "If you want to safely uninstall %s, please run %s/%s."
         package install_dir uninstall_script_name
     ]
+  in
+  let make_desktop_files =
+    let create_applications_dir =
+      [
+        create_if_not_found appdir_v;
+        mkdir ~permissions:755 [appdir_v];
+      ]
+    in
+    let create_desktop_file file =
+      let base_desktop_file = Filename.basename file in
+      let install_pattern = "%{install_path}" in
+      let installed = appdir_v / base_desktop_file in
+      Sh_script.[
+        Cp { src = file ; dst = installed } ;
+        Chmod { permissions = 644 ; files = [ installed ] } ;
+        Sed {
+          file = installed ;
+          pattern = install_pattern ; value = install_path_v
+        } ;
+        if_ Is_not_root [
+          write_file ~append:true installed
+          [ "NoDisplay=true" ]
+        ] () ;
+        echof "Adding %s to %s" base_desktop_file appdir_v
+      ]
+    in
+    let files =
+      List.fold_left
+        begin fun acc exec_file ->
+          match exec_file.Installer_config.desktop_tpl with
+          | None -> acc
+          | Some file -> (create_desktop_file file) @ acc
+        end
+        [] ic.exec_files
+    in
+    match files with
+    | [] -> []
+    | files -> create_applications_dir @ files
   in
   let install_plugins = List.concat_map (install_plugin ~install_dir) ic.plugins in
   let dump_install_conf =
@@ -572,6 +630,7 @@ let install_script ~installer_name (ic : Installer_config.internal) =
   @ install_binaries
   @ install_manpages
   @ install_plugins
+  @ make_desktop_files
   @ notify_install_complete
 
 let display_plugin (plugin : Installer_config.plugin) =
@@ -616,6 +675,16 @@ let uninstall_script (ic : Installer_config.internal) =
       )
       binaries
   in
+  let display_desktop_files =
+    let out_file file =
+      Sh_script.echof "- %s" (appdir_v / Filename.basename file)
+    in
+    List.filter_map
+      begin fun Installer_config.{ desktop_tpl  ; _} ->
+        Option.map out_file desktop_tpl
+      end
+      ic.exec_files
+  in
   let manpages = Option.value ic.manpages ~default:[] in
   let display_manpages =
     List.concat_map
@@ -651,6 +720,7 @@ let uninstall_script (ic : Installer_config.internal) =
     @ display_symlinks
     @ display_manpages
     @ display_plugins
+    @ display_desktop_files
   in
   let check_permissions =
     [ if_ Is_not_root
@@ -688,6 +758,19 @@ let uninstall_script (ic : Installer_config.internal) =
            pages)
       manpages
   in
+  let remove_desktop_files =
+    let out_file file = appdir_v / Filename.basename file in
+    let files =
+      List.filter_map
+        begin fun Installer_config.{ desktop_tpl  ; _} ->
+          Option.map out_file desktop_tpl
+        end
+        ic.exec_files
+    in
+    match files with
+    | [] -> []
+    | files -> [Sh_script.Rm { files ; rec_ = false}]
+  in
   let remove_plugins = List.concat_map uninstall_plugin ic.plugins in
   let notify_uninstall_complete = [echof "Uninstallation complete!"] in
   setup
@@ -697,6 +780,7 @@ let uninstall_script (ic : Installer_config.internal) =
   @ remove_symlinks
   @ remove_manpages
   @ remove_plugins
+  @ remove_desktop_files
   @ notify_uninstall_complete
 
 let add_sos_to_bundle ~bundle_dir (binary : Installer_config.exec_file) =

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -416,6 +416,50 @@ let read_arguments =
         ]
   ]
 
+let install_desktop_files ic =
+  let open Sh_script in
+  let create_applications_dir =
+    [
+      create_if_not_found appdir_v;
+      mkdir ~permissions:755 [appdir_v];
+    ]
+  in
+  let sed_script_nv = "tmpsedscript" in
+  let sed_script_v = !$ sed_script_nv in
+  let create_sed_script =
+    [ assign_eval sed_script_nv (mktemp ())
+    ; write_file sed_script_v
+        [ Printf.sprintf "s/%%{install_path}/%s/g" install_path_v
+        ]
+    ]
+  in
+  let rm_sed_script = [rm [sed_script_v]] in
+  let create_desktop_file template =
+    let base_desktop_file = Filename.basename template in
+    let installed = appdir_v / base_desktop_file in
+    [
+      echof "Adding %s to %s" base_desktop_file appdir_v;
+      sed ~script:sed_script_v ~in_:template ~out:installed;
+      chmod 644 [ installed ];
+      if_ Is_not_root
+        [ write_file ~append:true installed [ "NoDisplay=true" ]] ();
+    ]
+  in
+  let install_desktop_files =
+    List.filter_map
+      (fun exec_file ->
+         Option.map
+           create_desktop_file
+           exec_file.Installer_config.desktop_tpl)
+      ic.Installer_config.exec_files
+  in
+  match install_desktop_files with
+  | [] -> []
+  | files ->
+    List.concat
+      (create_applications_dir::create_sed_script::files)
+    @ rm_sed_script
+
 let install_script ~installer_name (ic : Installer_config.internal) =
   let open Sh_script in
   let package = ic.name in
@@ -554,44 +598,7 @@ let install_script ~installer_name (ic : Installer_config.internal) =
         package install_dir uninstall_script_name
     ]
   in
-  let make_desktop_files =
-    let create_applications_dir =
-      [
-        create_if_not_found appdir_v;
-        mkdir ~permissions:755 [appdir_v];
-      ]
-    in
-    let create_desktop_file file =
-      let base_desktop_file = Filename.basename file in
-      let install_pattern = "%{install_path}" in
-      let installed = appdir_v / base_desktop_file in
-      Sh_script.[
-        Cp { src = file ; dst = installed } ;
-        Chmod { permissions = 644 ; files = [ installed ] } ;
-        Sed {
-          file = installed ;
-          pattern = install_pattern ; value = install_path_v
-        } ;
-        if_ Is_not_root [
-          write_file ~append:true installed
-          [ "NoDisplay=true" ]
-        ] () ;
-        echof "Adding %s to %s" base_desktop_file appdir_v
-      ]
-    in
-    let files =
-      List.fold_left
-        begin fun acc exec_file ->
-          match exec_file.Installer_config.desktop_tpl with
-          | None -> acc
-          | Some file -> (create_desktop_file file) @ acc
-        end
-        [] ic.exec_files
-    in
-    match files with
-    | [] -> []
-    | files -> create_applications_dir @ files
-  in
+  let install_desktop_files = install_desktop_files ic in
   let install_plugins = List.concat_map (install_plugin ~install_dir) ic.plugins in
   let dump_install_conf =
     let lines =
@@ -630,7 +637,7 @@ let install_script ~installer_name (ic : Installer_config.internal) =
   @ install_binaries
   @ install_manpages
   @ install_plugins
-  @ make_desktop_files
+  @ install_desktop_files
   @ notify_install_complete
 
 let display_plugin (plugin : Installer_config.plugin) =

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -416,6 +416,11 @@ let read_arguments =
         ]
   ]
 
+let desktop_file_basename ic exec =
+  Printf.sprintf "%s.%s.desktop"
+    ic.Installer_config.unique_id
+    (Filename.basename (Filename.remove_extension exec.Installer_config.path))
+
 let install_desktop_files ic =
   let open Sh_script in
   let create_applications_dir =
@@ -434,8 +439,8 @@ let install_desktop_files ic =
     ]
   in
   let rm_sed_script = [rm [sed_script_v]] in
-  let create_desktop_file template =
-    let base_desktop_file = Filename.basename template in
+  let create_desktop_file ~template exec =
+    let base_desktop_file = desktop_file_basename ic exec in
     let installed = appdir_v / base_desktop_file in
     [
       echof "Adding %s to %s" base_desktop_file appdir_v;
@@ -451,7 +456,7 @@ let install_desktop_files ic =
     List.filter_map
       (fun exec_file ->
          Option.map
-           create_desktop_file
+           (fun template -> create_desktop_file ~template exec_file)
            exec_file.Installer_config.desktop_tpl)
       ic.Installer_config.exec_files
   in
@@ -685,14 +690,14 @@ let uninstall_script (ic : Installer_config.internal) =
       binaries
   in
   let display_desktop_files =
-    let out_file file =
-      Sh_script.echof "- %s" (appdir_v / Filename.basename file)
+    let out_file exec =
+      match exec.Installer_config.desktop_tpl with
+      | None -> None
+      | Some _ ->
+        Some
+          (Sh_script.echof "- %s" (appdir_v / (desktop_file_basename ic exec)))
     in
-    List.filter_map
-      begin fun Installer_config.{ desktop_tpl  ; _} ->
-        Option.map out_file desktop_tpl
-      end
-      ic.exec_files
+    List.filter_map out_file ic.exec_files
   in
   let manpages = Option.value ic.manpages ~default:[] in
   let display_manpages =
@@ -768,14 +773,12 @@ let uninstall_script (ic : Installer_config.internal) =
       manpages
   in
   let remove_desktop_files =
-    let out_file file = appdir_v / Filename.basename file in
-    let files =
-      List.filter_map
-        begin fun Installer_config.{ desktop_tpl  ; _} ->
-          Option.map out_file desktop_tpl
-        end
-        ic.exec_files
+    let out_file exec =
+      Option.map
+        (fun _ -> appdir_v / (desktop_file_basename ic exec))
+        exec.desktop_tpl
     in
+    let files = List.filter_map out_file ic.exec_files in
     match files with
     | [] -> []
     | files -> [Sh_script.Rm { files ; rec_ = false}]

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -441,6 +441,8 @@ let install_desktop_files ic =
       echof "Adding %s to %s" base_desktop_file appdir_v;
       sed ~script:sed_script_v ~in_:template ~out:installed;
       chmod 644 [ installed ];
+      (* This next command is a temporary fix for frama-c, to remove once
+         post-install scripts are permitted. *)
       if_ Is_not_root
         [ write_file ~append:true installed [ "NoDisplay=true" ]] ();
     ]

--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -43,8 +43,8 @@ module Global = struct
   let pre = "/usr/local"
   let bin = pre / "bin"
   let shareman = pre / "share/man"
-  let shareapplications = pre / "share/applications"
-  let localshareapplications = pre / "local/share/applications"
+  let shareapplications = "/usr/share/applications"
+  let localshareapplications = pre / "share/applications"
   let man = pre / "man"
 end
 

--- a/src/oui_lib/opam_frontend.ml
+++ b/src/oui_lib/opam_frontend.ml
@@ -363,7 +363,11 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
   let name = OpamPackage.Name.to_string (OpamPackage.name package) in
   let exec_files =
     List.map (fun x ->
-        { path = OpamFilename.Base.to_string x; symlink = true; deps = true }
+        { path = OpamFilename.Base.to_string x;
+          symlink = true;
+          deps = true;
+          desktop_tpl = None;
+        }
       ) exe_bases
   in
   let wix_manufacturer = String.concat ", " (OpamFile.OPAM.maintainer opam) in

--- a/src/oui_lib/sh_script.ml
+++ b/src/oui_lib/sh_script.ml
@@ -66,7 +66,8 @@ type command =
   | Read_file of {file: string; line_var: string; process_line: command list}
   | Def_fun of {name: string; body : command list}
   | Call_fun of {name: string; args: string list}
-  | Sed of {file: string; pattern: string; value: string}
+  | Sed of {script: string; in_: string; out: string}
+  | Mktemp
 and case =
   { pattern : string
   ; commands : command list
@@ -106,6 +107,10 @@ let set_permissions_in ~on ~permissions starting_point =
   Set_permissions_in {on; permissions; starting_point}
 
 let copy_all_in ~src ~dst ~except = Copy_all_in {src; dst; except}
+
+let sed ~script ~in_ ~out = Sed {script; in_; out}
+
+let mktemp () = Mktemp
 
 let pp_sh_find_type fmtr ft =
   match ft with
@@ -229,8 +234,10 @@ let rec pp_sh_command ?(newline=true) ~indent fmtr command =
     fpf "%s" name
   | Call_fun {name; args} ->
     fpf "%s %s" name (String.concat " " args)
-  | Sed {file; pattern; value} ->
-    fpf "sed -i 's,%s,'\"%s\"',' %s" pattern value file
+  | Sed {script; in_; out} ->
+    fpf "sed -f \"%s\" \"%s\" > \"%s\"" script in_ out
+  | Mktemp ->
+    fpf "mktemp"
 
 and pp_sh_case ~indent fmtr {pattern; commands} =
   let indent_str = String.make indent ' ' in

--- a/src/oui_lib/sh_script.ml
+++ b/src/oui_lib/sh_script.ml
@@ -18,8 +18,8 @@ type numerical_op =
   | Eq
 
 type string_op =
- | Not_empty of string
- | Equal of string * string
+  | Not_empty of string
+  | Equal of string * string
 
 type condition =
   | Exists of string
@@ -66,6 +66,7 @@ type command =
   | Read_file of {file: string; line_var: string; process_line: command list}
   | Def_fun of {name: string; body : command list}
   | Call_fun of {name: string; args: string list}
+  | Sed of {file: string; pattern: string; value: string}
 and case =
   { pattern : string
   ; commands : command list
@@ -228,6 +229,8 @@ let rec pp_sh_command ?(newline=true) ~indent fmtr command =
     fpf "%s" name
   | Call_fun {name; args} ->
     fpf "%s %s" name (String.concat " " args)
+  | Sed {file; pattern; value} ->
+    fpf "sed -i 's,%s,'\"%s\"',' %s" pattern value file
 
 and pp_sh_case ~indent fmtr {pattern; commands} =
   let indent_str = String.make indent ' ' in

--- a/src/oui_lib/sh_script.mli
+++ b/src/oui_lib/sh_script.mli
@@ -66,6 +66,7 @@ type command =
   | Read_file of {file: string; line_var: string; process_line: command list}
   | Def_fun of {name: string; body : command list}
   | Call_fun of {name: string; args: string list}
+  | Sed of {file: string; pattern: string; value: string}
 and case =
   { pattern : string
   ; commands : command list

--- a/src/oui_lib/sh_script.mli
+++ b/src/oui_lib/sh_script.mli
@@ -66,7 +66,8 @@ type command =
   | Read_file of {file: string; line_var: string; process_line: command list}
   | Def_fun of {name: string; body : command list}
   | Call_fun of {name: string; args: string list}
-  | Sed of {file: string; pattern: string; value: string}
+  | Sed of {script: string; in_: string; out: string}
+  | Mktemp
 and case =
   { pattern : string
   ; commands : command list
@@ -182,5 +183,10 @@ val def_fun : string -> command list -> command
 
 (** [call_fun name [arg1; arg2] is ["name arg1 arg2"] *)
 val call_fun : string -> string list -> command
+
+(** [sed ~script ~in_ ~out] is ["sed -f script in_ > out"] *)
+val sed : script: string -> in_: string -> out: string -> command
+
+val mktemp : unit -> command
 
 val save : t -> OpamFilename.t -> unit

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -73,8 +73,14 @@ let%expect_test "install_script: simple" =
   in
   let config =
     make_config ~name:"aaa" ~version:"x.y.z"
-      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
-                   { path = "aaa-utility"; symlink = true; deps = true } ]
+      ~exec_files:[
+        { path = "aaa-command"
+        ; symlink = true
+        ; deps = true
+        ; desktop_tpl = Some "file.desktop"
+        };
+        { path = "aaa-utility"; symlink = true; deps = true ; desktop_tpl = None }
+      ]
       ~manpages
       ()
   in
@@ -111,6 +117,11 @@ let%expect_test "install_script: simple" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -158,6 +169,7 @@ let%expect_test "install_script: simple" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -178,6 +190,7 @@ let%expect_test "install_script: simple" =
     echo "- $PREFIX/aaa"
     echo "- $BINDIR/aaa-command"
     echo "- $BINDIR/aaa-utility"
+    echo "- $APPDIR/file.desktop"
     echo "- $MANDIR/man1/aaa-command.1"
     echo "- $MANDIR/man1/aaa-utility.1"
     echo "- $MANDIR/man5/aaa-file.1"
@@ -185,6 +198,7 @@ let%expect_test "install_script: simple" =
     collect_existing "$PREFIX/aaa"
     collect_existing "$BINDIR/aaa-command"
     collect_existing "$BINDIR/aaa-utility"
+    collect_existing "$APPDIR/file.desktop"
     collect_existing "$MANDIR/man1/aaa-command.1"
     collect_existing "$MANDIR/man1/aaa-utility.1"
     collect_existing "$MANDIR/man5/aaa-file.1"
@@ -231,6 +245,19 @@ let%expect_test "install_script: simple" =
     ln -s "$PREFIX/aaa/man/man1/aaa-utility.1" "$MANDIR/man1/aaa-utility.1"
     mkdir -p -m 755 "$MANDIR/man5"
     ln -s "$PREFIX/aaa/man/man5/aaa-file.1" "$MANDIR/man5/aaa-file.1"
+    if ! [ -d "$APPDIR" ]; then
+      mkdir -p -m 755 "$APPDIR"
+    fi
+    mkdir -p -m 755 "$APPDIR"
+    cp file.desktop $APPDIR/file.desktop
+    chmod 644 "$APPDIR/file.desktop"
+    sed -i 's,%{install_path},'"$INSTALL_PATH"',' $APPDIR/file.desktop
+    if [ "$(id -u)" -ne 0 ]; then
+      {
+        printf '%s\n' "NoDisplay=true"
+      } >> "$APPDIR/file.desktop"
+    fi
+    echo "Adding file.desktop to $APPDIR"
     echo "Installation complete!"
     echo "If you want to safely uninstall aaa, please run $PREFIX/aaa/uninstall.sh."
     |}]
@@ -273,6 +300,11 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -320,6 +352,7 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -462,6 +495,11 @@ let%expect_test "install_script: install plugins" =
     else
       MANDIR="/usr/local/man"
     fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
+    fi
     while [ $# -gt 0 ]; do
       case "$1" in
         --prefix)
@@ -508,6 +546,7 @@ let%expect_test "install_script: install plugins" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -667,12 +706,18 @@ let%expect_test "uninstall_script: uninstall plugins" =
     if [ "$IS_USER_INSTALL" = "true" ]; then
       BINDIR="$HOME/.local/bin"
       MANDIR="$HOME/.local/man"
+      APPDIR="$HOME/.local/share/applications"
     else
       BINDIR="/usr/local/bin"
       if [ -d "/usr/local/share/man" ]; then
         MANDIR="/usr/local/share/man"
       else
         MANDIR="/usr/local/man"
+      fi
+      if [ -d "/usr/local/share/applications" ]; then
+        APPDIR="/usr/local/share/applications"
+      else
+        APPDIR="/usr/local/local/share/applications"
       fi
     fi
     echo "About to uninstall t-name."
@@ -740,8 +785,10 @@ let%expect_test "uninstall_script: simple" =
   in
   let config =
     make_config ~name:"aaa"
-      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
-                   { path = "aaa-utility"; symlink = true; deps = true } ]
+      ~exec_files:[
+        { path = "aaa-command"; symlink = true; deps = true ; desktop_tpl = None };
+        { path = "aaa-utility"; symlink = true; deps = true ; desktop_tpl = None }
+      ]
       ~manpages
       ()
   in
@@ -787,12 +834,18 @@ let%expect_test "uninstall_script: simple" =
     if [ "$IS_USER_INSTALL" = "true" ]; then
       BINDIR="$HOME/.local/bin"
       MANDIR="$HOME/.local/man"
+      APPDIR="$HOME/.local/share/applications"
     else
       BINDIR="/usr/local/bin"
       if [ -d "/usr/local/share/man" ]; then
         MANDIR="/usr/local/share/man"
       else
         MANDIR="/usr/local/man"
+      fi
+      if [ -d "/usr/local/share/applications" ]; then
+        APPDIR="/usr/local/share/applications"
+      else
+        APPDIR="/usr/local/local/share/applications"
       fi
     fi
     echo "About to uninstall aaa."
@@ -849,7 +902,11 @@ let%expect_test "uninstall_script: simple" =
 (* Regression test that ensures that if the binaries are not at the bundle's
    root, the symlink are still installed correctly. *)
 let%expect_test "install_script: binary in sub folder" =
-  let config = make_config ~exec_files:[{ path = "bin/do"; symlink = true; deps = true }] () in
+  let config = make_config
+      ~exec_files:[
+        { path = "bin/do"; symlink = true; deps = true; desktop_tpl = None }
+      ] ()
+  in
   let installer_name = "installer.run" in
   let install_script = Makeself_backend.install_script ~installer_name config in
   Format.printf "%a" pp_sh install_script;
@@ -883,6 +940,11 @@ let%expect_test "install_script: binary in sub folder" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -930,6 +992,7 @@ let%expect_test "install_script: binary in sub folder" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"
@@ -994,7 +1057,10 @@ let%expect_test "install_script: binary in sub folder" =
 (* Regression test that ensures that if the binaries are not at the bundle's
    root, the symlinks are correctly removed by the uninstall script. *)
 let%expect_test "uninstall_script: binary in sub folder" =
-  let config = make_config ~exec_files:[{ path = "bin/do"; symlink = true; deps = true }] () in
+  let config = make_config ~exec_files:[
+      { path = "bin/do"; symlink = true; deps = true ; desktop_tpl = None }
+    ] ()
+  in
   let uninstall_script = Makeself_backend.uninstall_script config in
   Format.printf "%a" pp_sh uninstall_script;
   [%expect {|
@@ -1037,12 +1103,18 @@ let%expect_test "uninstall_script: binary in sub folder" =
     if [ "$IS_USER_INSTALL" = "true" ]; then
       BINDIR="$HOME/.local/bin"
       MANDIR="$HOME/.local/man"
+      APPDIR="$HOME/.local/share/applications"
     else
       BINDIR="/usr/local/bin"
       if [ -d "/usr/local/share/man" ]; then
         MANDIR="/usr/local/share/man"
       else
         MANDIR="/usr/local/man"
+      fi
+      if [ -d "/usr/local/share/applications" ]; then
+        APPDIR="/usr/local/share/applications"
+      else
+        APPDIR="/usr/local/local/share/applications"
       fi
     fi
     echo "About to uninstall test-name."
@@ -1079,7 +1151,9 @@ let%expect_test "uninstall_script: binary in sub folder" =
 let%expect_test "install_script: set environment for binaries" =
   let config =
     make_config
-      ~exec_files:[{ path = "bin/app"; symlink = true; deps = true }]
+      ~exec_files:[
+        { path = "bin/app"; symlink = true; deps = true; desktop_tpl = None }
+      ]
       ~environment:[("VAR1", "value1"); ("VAR2", "$INSTALL_PATH/lib")]
       ()
   in
@@ -1116,6 +1190,11 @@ let%expect_test "install_script: set environment for binaries" =
       MANDIR="/usr/local/share/man"
     else
       MANDIR="/usr/local/man"
+    fi
+    if [ -d "/usr/local/share/applications" ]; then
+      APPDIR="/usr/local/share/applications"
+    else
+      APPDIR="/usr/local/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -1163,6 +1242,7 @@ let%expect_test "install_script: set environment for binaries" =
           IS_USER_INSTALL="true"
           BINDIR="$HOME/.local/bin"
           MANDIR="$HOME/.local/man"
+          APPDIR="$HOME/.local/share/applications"
         else
           echo "Not running as root. Aborting."
           echo "Need root permission for $dir_name"

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -118,10 +118,10 @@ let%expect_test "install_script: simple" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -301,10 +301,10 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -495,10 +495,10 @@ let%expect_test "install_script: install plugins" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -714,10 +714,10 @@ let%expect_test "uninstall_script: uninstall plugins" =
       else
         MANDIR="/usr/local/man"
       fi
-      if [ -d "/usr/local/share/applications" ]; then
-        APPDIR="/usr/local/share/applications"
+      if [ -d "/usr/share/applications" ]; then
+        APPDIR="/usr/share/applications"
       else
-        APPDIR="/usr/local/local/share/applications"
+        APPDIR="/usr/local/share/applications"
       fi
     fi
     echo "About to uninstall t-name."
@@ -842,10 +842,10 @@ let%expect_test "uninstall_script: simple" =
       else
         MANDIR="/usr/local/man"
       fi
-      if [ -d "/usr/local/share/applications" ]; then
-        APPDIR="/usr/local/share/applications"
+      if [ -d "/usr/share/applications" ]; then
+        APPDIR="/usr/share/applications"
       else
-        APPDIR="/usr/local/local/share/applications"
+        APPDIR="/usr/local/share/applications"
       fi
     fi
     echo "About to uninstall aaa."
@@ -941,10 +941,10 @@ let%expect_test "install_script: binary in sub folder" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -1111,10 +1111,10 @@ let%expect_test "uninstall_script: binary in sub folder" =
       else
         MANDIR="/usr/local/man"
       fi
-      if [ -d "/usr/local/share/applications" ]; then
-        APPDIR="/usr/local/share/applications"
+      if [ -d "/usr/share/applications" ]; then
+        APPDIR="/usr/share/applications"
       else
-        APPDIR="/usr/local/local/share/applications"
+        APPDIR="/usr/local/share/applications"
       fi
     fi
     echo "About to uninstall test-name."
@@ -1191,10 +1191,10 @@ let%expect_test "install_script: set environment for binaries" =
     else
       MANDIR="/usr/local/man"
     fi
-    if [ -d "/usr/local/share/applications" ]; then
-      APPDIR="/usr/local/share/applications"
+    if [ -d "/usr/share/applications" ]; then
+      APPDIR="/usr/share/applications"
     else
-      APPDIR="/usr/local/local/share/applications"
+      APPDIR="/usr/local/share/applications"
     fi
     while [ $# -gt 0 ]; do
       case "$1" in

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -34,6 +34,7 @@ let make_expanded_manpages
   |> List.filter_map (function _, [] -> None | x -> Some x)
 
 let make_config
+    ?(unique_id="com.test")
     ?(name="test-name")
     ?(version="test.version")
     ?(exec_files=[])
@@ -49,7 +50,7 @@ let make_config
   ; fullname = ""
   ; manpages
   ; environment
-  ; unique_id = ""
+  ; unique_id
   ; plugins
   ; plugin_dirs
   ; wix_manufacturer = ""
@@ -72,7 +73,7 @@ let%expect_test "install_script: simple" =
       ()
   in
   let config =
-    make_config ~name:"aaa" ~version:"x.y.z"
+    make_config ~unique_id:"com.a" ~name:"aaa" ~version:"x.y.z"
       ~exec_files:[
         { path = "aaa-command"
         ; symlink = true
@@ -253,13 +254,13 @@ let%expect_test "install_script: simple" =
     {
       printf '%s\n' "s/%{install_path}/$INSTALL_PATH/g"
     } > "$tmpsedscript"
-    echo "Adding file.desktop to $APPDIR"
-    sed -f "$tmpsedscript" "file.desktop" > "$APPDIR/file.desktop"
-    chmod 644 "$APPDIR/file.desktop"
+    echo "Adding com.a.aaa-command.desktop to $APPDIR"
+    sed -f "$tmpsedscript" "file.desktop" > "$APPDIR/com.a.aaa-command.desktop"
+    chmod 644 "$APPDIR/com.a.aaa-command.desktop"
     if [ "$(id -u)" -ne 0 ]; then
       {
         printf '%s\n' "NoDisplay=true"
-      } >> "$APPDIR/file.desktop"
+      } >> "$APPDIR/com.a.aaa-command.desktop"
     fi
     rm -f "$tmpsedscript"
     echo "Installation complete!"
@@ -788,9 +789,10 @@ let%expect_test "uninstall_script: simple" =
       ()
   in
   let config =
-    make_config ~name:"aaa"
+    make_config ~unique_id:"com.a" ~name:"aaa"
       ~exec_files:[
-        { path = "aaa-command"; symlink = true; deps = true ; desktop_tpl = None };
+        { path = "aaa-command"; symlink = true; deps = true
+        ; desktop_tpl = Some "file.desktop" };
         { path = "aaa-utility"; symlink = true; deps = true ; desktop_tpl = None }
       ]
       ~manpages
@@ -860,6 +862,7 @@ let%expect_test "uninstall_script: simple" =
     echo "- $MANDIR/man1/aaa-command.1"
     echo "- $MANDIR/man1/aaa-utility.1"
     echo "- $MANDIR/man5/aaa-file.1"
+    echo "- $APPDIR/com.a.aaa-command.desktop"
     printf "Proceed? [y/N] "
     read ans
     case "$ans" in
@@ -900,6 +903,7 @@ let%expect_test "uninstall_script: simple" =
       echo "Removing manpage $MANDIR/man5/aaa-file.1..."
       rm -f "$MANDIR/man5/aaa-file.1"
     fi
+    rm -f "$APPDIR/com.a.aaa-command.desktop"
     echo "Uninstallation complete!"
     |}]
 

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -249,15 +249,19 @@ let%expect_test "install_script: simple" =
       mkdir -p -m 755 "$APPDIR"
     fi
     mkdir -p -m 755 "$APPDIR"
-    cp file.desktop $APPDIR/file.desktop
+    tmpsedscript="$(mktemp)"
+    {
+      printf '%s\n' "s/%{install_path}/$INSTALL_PATH/g"
+    } > "$tmpsedscript"
+    echo "Adding file.desktop to $APPDIR"
+    sed -f "$tmpsedscript" "file.desktop" > "$APPDIR/file.desktop"
     chmod 644 "$APPDIR/file.desktop"
-    sed -i 's,%{install_path},'"$INSTALL_PATH"',' $APPDIR/file.desktop
     if [ "$(id -u)" -ne 0 ]; then
       {
         printf '%s\n' "NoDisplay=true"
       } >> "$APPDIR/file.desktop"
     fi
-    echo "Adding file.desktop to $APPDIR"
+    rm -f "$tmpsedscript"
     echo "Installation complete!"
     echo "If you want to safely uninstall aaa, please run $PREFIX/aaa/uninstall.sh."
     |}]


### PR DESCRIPTION
This PR is based on the original work of @AllanBlanchard in #139.

It adds:
- a more portable and extensible sed invocation
- documentation
- a less likely to collide default name for installed desktop files