### PR TITLE
Allow signing macos binaries with developper ID certificate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Allow properly signing MacOS binaries with Developer ID certificate
+  (#147, @NathanReb)
+
 ### Changed
 
 - On linux, write `install.conf` earlier during install to allow recovering

--- a/doc/README.md
+++ b/doc/README.md
@@ -86,6 +86,10 @@ are:
   in `Contents/`. Used by macOS backend only. See
   [macOS / Application Bundle section](#macos--application-bundle) for details.
   *Example:* `["lib", "share"]`.
+- `macos_application_signing_id`: **string**, **optional**: Developer ID
+  Application or Common Name of certificate used to sign MacOS binaries
+  with `codesign`. If missing, binaries are signed with `codesign -s -`.
+  *Example:* `"Developer ID Application: John Smith (ABC123DEF)"`
 
 ### exec_files object
 

--- a/src/opam-oui/main.ml
+++ b/src/opam-oui/main.ml
@@ -11,6 +11,14 @@
 open OpamCmdliner
 open Oui
 
+let arg_from_abstract : type a. a Oui_cli.Args.abstract -> a Arg.t =
+  fun {names; docv; doc; kind} ->
+  let open Arg in
+  let info = info ~doc ~docv names in
+  match kind with
+  | Flag -> flag info
+  | String_opt default -> opt (some string) default info
+
 let package =
   let open Arg in
   required
@@ -18,20 +26,17 @@ let package =
   & info [] ~docv:"PACKAGE" ~docs:Oui_cli.Man.Section.package_arg
       ~doc:"The package to create an installer for"
 
+let macos_application_signing_id =
+  let open Arg in
+  value & arg_from_abstract Oui_cli.Args.macos_application_signing_id_abstract
+
 let opam_filename =
   let conv, pp = OpamArg.filename in
   ((fun filename_arg -> System.normalize_path filename_arg |> conv), pp)
 
 let output =
   let open Arg in
-  let doc =
-    "$(docv) installer or bundle name. Defaults to \
-     $(b,package-name.version.ext), in the current directory, where $(b,ext) \
-     is $(b,.msi) for Windows installers and $(b,.run) for Linux installers."
-  in
-  value
-  & opt (some string) None
-  & info ~docv:"OUTPUT" ~doc [ "o"; "output" ]
+  value & arg_from_abstract Oui_cli.Args.output_abstract
 
 let opam_conf_file =
   let open Arg in
@@ -44,7 +49,7 @@ let opam_conf_file =
 
 let wix_keep_wxs =
   let open Arg in
-  value & flag & info [ "keep-wxs" ] ~doc:"Keep Wix source files."
+  value & arg_from_abstract Oui_cli.Args.wix_keep_wxs_abstract
 
 let no_backend =
   let open Arg in
@@ -60,10 +65,17 @@ let save_bundle_and_conf ~(installer_config : Installer_config.user) ~bundle_dir
 
 let create_bundle cli =
   let doc = "Extract package installer bundle" in
-  let create_bundle global_options conf_file keep_wxs no_backend output
-      package () =
+  let create_bundle global_options conf_file
+      (`App_signing_id macos_application_signing_id)
+      (`Keep_wxs keep_wxs) (`No_backend no_backend) (`Output output) package ()
+    =
     Opam_frontend.with_install_bundle ?conf_file cli global_options package
       (fun installer_config ~bundle_dir ~tmp_dir ->
+         let installer_config =
+           Oui_cli.Args.override_config
+             ~macos_application_signing_id
+             installer_config
+         in
          let backend =
            if no_backend then
              None
@@ -105,9 +117,10 @@ let create_bundle cli =
     Term.(const create_bundle
           $ OpamArg.global_options cli
           $ opam_conf_file
-          $ wix_keep_wxs
-          $ no_backend
-          $ output
+          $ map (fun x -> `App_signing_id x) macos_application_signing_id
+          $ map (fun x -> `Keep_wxs x) wix_keep_wxs
+          $ map (fun x -> `No_backend x) no_backend
+          $ map (fun x -> `Output x) output
           $ package)
 
 let () =

--- a/src/oui/build.ml
+++ b/src/oui/build.ml
@@ -10,8 +10,10 @@
 
 open Oui
 
-let run keep_wxs backend mtime tar_extra installer_config bundle_dir output
-  verbose_level debug_level =
+let run (`Keep_wxs keep_wxs) (`Backend backend) (`Mtime mtime)
+    (`Tar_extra tar_extra) (`App_signing_id macos_application_signing_id)
+    (`Installer_config installer_config) (`Bundle_dir bundle_dir)
+    (`Output output) (`Verbose verbose_level) (`Debug debug_level) =
   OpamCoreConfig.init ~verbose_level ~debug_level ();
   let res =
     let open Letop.Result in
@@ -22,6 +24,11 @@ let run keep_wxs backend mtime tar_extra installer_config bundle_dir output
     in
     Oui_cli.Warnings.handle warnings;
     let+ installer_config = res in
+    let installer_config =
+      Oui_cli.Args.override_config
+        ~macos_application_signing_id
+        installer_config
+    in
     let output =
       Oui_cli.Args.output_name ~output ~backend:(Some backend) installer_config
     in
@@ -46,15 +53,16 @@ let run keep_wxs backend mtime tar_extra installer_config bundle_dir output
 let term =
   let open Cmdliner.Term in
   const run
-  $ Oui_cli.Args.wix_keep_wxs
-  $ Oui_cli.Args.backend
-  $ Oui_cli.Args.mtime
-  $ Oui_cli.Args.tar_extra
-  $ Oui_cli.Args.installer_config
-  $ Oui_cli.Args.bundle_dir
-  $ Oui_cli.Args.output
-  $ Oui_cli.Args.verbose
-  $ Oui_cli.Args.debug
+  $ map (fun x -> `Keep_wxs x) Oui_cli.Args.wix_keep_wxs
+  $ map (fun x -> `Backend x) Oui_cli.Args.backend
+  $ map (fun x -> `Mtime x) Oui_cli.Args.mtime
+  $ map (fun x -> `Tar_extra x) Oui_cli.Args.tar_extra
+  $ map (fun x -> `App_signing_id x) Oui_cli.Args.macos_application_signing_id
+  $ map (fun x -> `Installer_config x) Oui_cli.Args.installer_config
+  $ map (fun x -> `Bundle_dir x) Oui_cli.Args.bundle_dir
+  $ map (fun x -> `Output x) Oui_cli.Args.output
+  $ map (fun x -> `Verbose x) Oui_cli.Args.verbose
+  $ map (fun x -> `Debug x) Oui_cli.Args.debug
 
 let cmd =
   let info =

--- a/src/oui_cli/args.ml
+++ b/src/oui_cli/args.ml
@@ -12,6 +12,27 @@ open Cmdliner
 open Cmdliner.Arg
 open Oui
 
+type 'a arg_kind =
+  | Flag : bool arg_kind
+  | String_opt : string option -> string option arg_kind
+
+type 'a abstract =
+  { names : string list
+  ; docv : string
+  ; doc : string
+  ; kind : 'a arg_kind
+  }
+(** Type describing individual elements of a CLI argument. Used to share
+    args between the main binary and the opam plugin which uses OpamCmdliner
+    and not Cmdliner itself. *)
+
+let arg_from_abstract : type a. a abstract -> a Cmdliner.Arg.t =
+  fun {names; docv; doc; kind} ->
+  let info = info ~doc ~docv names in
+  match kind with
+  | Flag -> flag info
+  | String_opt default -> opt (some string) default info
+
 let opam_filename =
   let conv, pp = OpamArg.filename in
   let parse filename_arg =
@@ -30,7 +51,14 @@ let opam_dirname =
   in
   Arg.conv' (parse, pp)
 
-let wix_keep_wxs = value & flag & info [ "keep-wxs" ] ~doc:"Keep Wix source files."
+let wix_keep_wxs_abstract =
+  { kind = Flag
+  ; docv = ""
+  ; doc = "Keep Wix source files."
+  ; names = [ "keep-wxs" ]
+  }
+
+let wix_keep_wxs = value & arg_from_abstract wix_keep_wxs_abstract
 
 type backend = Wix | Makeself | Pkgbuild
 
@@ -134,16 +162,19 @@ let backend_opt =
   in
   Cmdliner.Term.(const choose $ value arg)
 
+let output_abstract =
+  { kind = String_opt None
+  ; docv = "OUTPUT"
+  ; doc =
+      "$(docv) installer or bundle name. Defaults to \
+       $(b,package-name.version.ext), in the current directory, where $(b,ext) \
+       is $(b,.msi) for Windows installers and $(b,.run) for Linux installers."
+  ; names = [ "o"; "output" ]
+  }
+
 let output =
   let open Arg in
-  let doc =
-    "$(docv) installer or bundle name. Defaults to \
-     $(b,package-name.version.ext), in the current directory, where $(b,ext) \
-     is $(b,.msi) for Windows installers and $(b,.run) for Linux installers."
-  in
-  value
-  & opt (some string) None
-  & info ~docv:"OUTPUT" ~doc [ "o"; "output" ]
+  value & arg_from_abstract output_abstract
 
 let output_name ~output ~backend (ic : _ Installer_config.t) =
   match output with
@@ -158,6 +189,18 @@ let output_name ~output ~backend (ic : _ Installer_config.t) =
       | Some Pkgbuild -> ".pkg"
     in
     base ^ ext
+
+let override_config
+    ~macos_application_signing_id
+    (ic : Installer_config.internal) =
+  let override ~default cli_opt =
+    match cli_opt with None -> default | Some _ -> cli_opt
+  in
+  let macos_application_signing_id =
+    override ~default:ic.macos_application_signing_id
+      macos_application_signing_id
+  in
+  {ic with macos_application_signing_id}
 
 let installer_config =
   let open Cmdliner.Arg in
@@ -198,3 +241,16 @@ let tar_extra =
      creating makeself installer."
   in
   value & opt (some ~none (list string)) None & info ["tar-extra"] ~doc
+
+let macos_application_signing_id_abstract =
+  { kind = String_opt None
+  ; docv = "DEVELOPER_ID_APPLICATION"
+  ; doc =
+      "Developer ID application certificate name to use with codesign. \
+       This option has higher priority than the \
+       $(b,macos_application_signing_id) JSON config field."
+  ; names = ["macos-binary-signing-id"]
+  }
+
+let macos_application_signing_id =
+  value & arg_from_abstract macos_application_signing_id_abstract

--- a/src/oui_cli/args.mli
+++ b/src/oui_cli/args.mli
@@ -8,11 +8,28 @@
 (*                                                                        *)
 (**************************************************************************)
 
+
+type 'a arg_kind =
+  | Flag : bool arg_kind
+  | String_opt : string option -> string option arg_kind
+
+type 'a abstract =
+  { names : string list
+  ; docv : string
+  ; doc : string
+  ; kind : 'a arg_kind
+  }
+(** Type describing individual elements of a CLI argument. Used to share
+    args between the main binary and the opam plugin which uses OpamCmdliner
+    and not Cmdliner itself. *)
+
 val opam_filename : OpamFilename.t Cmdliner.Arg.conv
 val opam_dirname : OpamFilename.Dir.t Cmdliner.Arg.conv
 
 val wix_keep_wxs : bool Cmdliner.Term.t
 (** --keep-wxs flag to disable WiX files clean up. *)
+
+val wix_keep_wxs_abstract : bool abstract
 
 type backend = Wix | Makeself | Pkgbuild
 
@@ -35,6 +52,8 @@ val backend_opt : backend option Cmdliner.Term.t
 val output : string option Cmdliner.Term.t
 (** -o/--output option to overwrite the default output file/dir. *)
 
+val output_abstract : string option abstract
+
 val output_name :
   output: string option ->
   backend: backend option ->
@@ -42,6 +61,12 @@ val output_name :
   string
 (** Returns the approriate output name based on the value of the
     -o and --backend options. *)
+
+(** Overrides some config fields with higher priority CLI options *)
+val override_config :
+  macos_application_signing_id: string option ->
+  Oui.Installer_config.internal -> 
+  Oui.Installer_config.internal
 
 (** JSON oui config file positional argument, sits as first positional arg. *)
 val installer_config : OpamFilename.t Cmdliner.Term.t
@@ -60,3 +85,10 @@ val mtime : string option Cmdliner.Term.t
 
 (** Extra tar option for makeself archives *)
 val tar_extra : string list option Cmdliner.Term.t
+
+(** --macos-application-signing-id option to pass Developer ID Application
+    certificate name to codesign for binary signature. Overrides the JSON
+    config field. *)
+val macos_application_signing_id : string option Cmdliner.Term.t
+
+val macos_application_signing_id_abstract : string option abstract

--- a/src/oui_lib/installer_config.ml
+++ b/src/oui_lib/installer_config.ml
@@ -104,6 +104,7 @@ type ('manpages, 'env_val) t = {
     wix_banner_bmp_file : string option; [@default None]
     wix_license_file : string option; [@default None]
     macos_symlink_dirs : string list; [@default []]
+    macos_application_signing_id: string option; [@default None]
   }
 [@@deriving yojson {meta = true}]
 

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -87,6 +87,9 @@ type ('manpages, 'string_with_vars) t = {
     macos_symlink_dirs : string list;
     (** Directories to symlink from Contents/ to Resources/ for dune-site relocatable support.
         Example: ["lib"; "share"] creates Contents/lib -> Resources/lib and Contents/share -> Resources/share *)
+    macos_application_signing_id: string option;
+    (** Developer ID Application certificate, passed to codesign to sign
+        binaries *)
   }
 
 type user = (manpages, String_with_vars.t) t

--- a/src/oui_lib/opam_frontend.ml
+++ b/src/oui_lib/opam_frontend.ml
@@ -386,6 +386,7 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
      wix_banner_bmp_file = opam_oui_conf.c_images.ban;
      wix_license_file = None; (* TODO *)
      macos_symlink_dirs = []; (* TODO *)
+     macos_application_signing_id = None;
    })
 
 let with_opam_and_conf ~conf_file cli global_options f =

--- a/src/oui_lib/pkgbuild_backend.ml
+++ b/src/oui_lib/pkgbuild_backend.ml
@@ -114,9 +114,15 @@ let create_installer
         Macos_app_bundle.install_binary bundle ~binary_path:binary_src
       in
       handle_dylibs bundle ~binary_dst;
-      (* Sign the binary with ad-hoc signature *)
-      OpamConsole.msg "Signing binary...\n";
-      Codesign.sign_binary_adhoc binary_dst;
+      (* Sign the binary*)
+      OpamConsole.msg "Signing binary (%s)\n"
+        (match installer_config.macos_application_signing_id with
+         | None -> "ad-hoc"
+         | Some cert_name -> "with "^cert_name);
+      (match installer_config.macos_application_signing_id with
+       | None -> Codesign.sign_binary_adhoc binary_dst
+       | Some cert_name ->
+         Codesign.sign_binary_with_dev_id ~cert_name binary_dst);
       Some bundle.binary_name
   in
 

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -60,6 +60,7 @@ let make_config
   ; wix_banner_bmp_file = None
   ; wix_license_file = None
   ; macos_symlink_dirs = []
+  ; macos_application_signing_id = None
   }
 
 let pp_sh = Sh_script.pp_sh ~version:false


### PR DESCRIPTION
This simply plugs the existing but unreachable support for proper binary signing on MacOS by adding both a JSON config field and command line option to set the developer ID certificate name to forward to `codesign`.

When absent, we default to the current behaviour of adhoc signature with `codesign -s -` which is just a hash for integrity checks.

This is a first step towards fixing #143. I'll add the productsign counterpart in a separate PR.