### PR TITLE
Allow signing macos .pkg installers with Developer ID certificate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Allow properly signing MacOS binaries with Developer ID certificate
   (#147, @NathanReb)
+- Allow signing MacOS .pkg installers with Developer ID certificate
+  (#148, @NathanReb)
 
 ### Changed
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -90,6 +90,10 @@ are:
   Application or Common Name of certificate used to sign MacOS binaries
   with `codesign`. If missing, binaries are signed with `codesign -s -`.
   *Example:* `"Developer ID Application: John Smith (ABC123DEF)"`
+- `macos_installer_signing_id`: **string**, **optional**: Developer ID
+  Installer or Common Name of certificate used to sign MacOS .pkg installers
+  with `productbuild`. If missing, .pkg are left unsigned.
+  *Example:* `"Developer ID Installer: John Smith (ABC123DEF)"`
 
 ### exec_files object
 

--- a/src/opam-oui/main.ml
+++ b/src/opam-oui/main.ml
@@ -30,6 +30,10 @@ let macos_application_signing_id =
   let open Arg in
   value & arg_from_abstract Oui_cli.Args.macos_application_signing_id_abstract
 
+let macos_installer_signing_id =
+  let open Arg in
+  value & arg_from_abstract Oui_cli.Args.macos_installer_signing_id_abstract
+
 let opam_filename =
   let conv, pp = OpamArg.filename in
   ((fun filename_arg -> System.normalize_path filename_arg |> conv), pp)
@@ -67,6 +71,7 @@ let create_bundle cli =
   let doc = "Extract package installer bundle" in
   let create_bundle global_options conf_file
       (`App_signing_id macos_application_signing_id)
+      (`Installer_signing_id macos_installer_signing_id)
       (`Keep_wxs keep_wxs) (`No_backend no_backend) (`Output output) package ()
     =
     Opam_frontend.with_install_bundle ?conf_file cli global_options package
@@ -74,6 +79,7 @@ let create_bundle cli =
          let installer_config =
            Oui_cli.Args.override_config
              ~macos_application_signing_id
+             ~macos_installer_signing_id
              installer_config
          in
          let backend =
@@ -118,6 +124,7 @@ let create_bundle cli =
           $ OpamArg.global_options cli
           $ opam_conf_file
           $ map (fun x -> `App_signing_id x) macos_application_signing_id
+          $ map (fun x -> `Installer_signing_id x) macos_installer_signing_id
           $ map (fun x -> `Keep_wxs x) wix_keep_wxs
           $ map (fun x -> `No_backend x) no_backend
           $ map (fun x -> `Output x) output

--- a/src/oui/build.ml
+++ b/src/oui/build.ml
@@ -12,6 +12,7 @@ open Oui
 
 let run (`Keep_wxs keep_wxs) (`Backend backend) (`Mtime mtime)
     (`Tar_extra tar_extra) (`App_signing_id macos_application_signing_id)
+    (`Installer_signing_id macos_installer_signing_id)
     (`Installer_config installer_config) (`Bundle_dir bundle_dir)
     (`Output output) (`Verbose verbose_level) (`Debug debug_level) =
   OpamCoreConfig.init ~verbose_level ~debug_level ();
@@ -27,6 +28,7 @@ let run (`Keep_wxs keep_wxs) (`Backend backend) (`Mtime mtime)
     let installer_config =
       Oui_cli.Args.override_config
         ~macos_application_signing_id
+        ~macos_installer_signing_id
         installer_config
     in
     let output =
@@ -58,6 +60,7 @@ let term =
   $ map (fun x -> `Mtime x) Oui_cli.Args.mtime
   $ map (fun x -> `Tar_extra x) Oui_cli.Args.tar_extra
   $ map (fun x -> `App_signing_id x) Oui_cli.Args.macos_application_signing_id
+  $ map (fun x -> `Installer_signing_id x) Oui_cli.Args.macos_installer_signing_id
   $ map (fun x -> `Installer_config x) Oui_cli.Args.installer_config
   $ map (fun x -> `Bundle_dir x) Oui_cli.Args.bundle_dir
   $ map (fun x -> `Output x) Oui_cli.Args.output

--- a/src/oui_cli/args.ml
+++ b/src/oui_cli/args.ml
@@ -192,6 +192,7 @@ let output_name ~output ~backend (ic : _ Installer_config.t) =
 
 let override_config
     ~macos_application_signing_id
+    ~macos_installer_signing_id
     (ic : Installer_config.internal) =
   let override ~default cli_opt =
     match cli_opt with None -> default | Some _ -> cli_opt
@@ -200,7 +201,11 @@ let override_config
     override ~default:ic.macos_application_signing_id
       macos_application_signing_id
   in
-  {ic with macos_application_signing_id}
+  let macos_installer_signing_id =
+    override ~default:ic.macos_installer_signing_id
+      macos_installer_signing_id
+  in
+  {ic with macos_application_signing_id; macos_installer_signing_id}
 
 let installer_config =
   let open Cmdliner.Arg in
@@ -254,3 +259,16 @@ let macos_application_signing_id_abstract =
 
 let macos_application_signing_id =
   value & arg_from_abstract macos_application_signing_id_abstract
+
+let macos_installer_signing_id_abstract =
+  { kind = String_opt None
+  ; docv = "DEVELOPER_ID_INSTALLER"
+  ; doc =
+      "Developer ID installer certificate name to use with productbuild. \
+       This option has higher priority than the \
+       $(b,macos_installer_signing_id) JSON config field."
+  ; names = ["macos-installer-signing-id"]
+  }
+
+let macos_installer_signing_id =
+  value & arg_from_abstract macos_installer_signing_id_abstract

--- a/src/oui_cli/args.mli
+++ b/src/oui_cli/args.mli
@@ -65,7 +65,8 @@ val output_name :
 (** Overrides some config fields with higher priority CLI options *)
 val override_config :
   macos_application_signing_id: string option ->
-  Oui.Installer_config.internal -> 
+  macos_installer_signing_id: string option ->
+  Oui.Installer_config.internal ->
   Oui.Installer_config.internal
 
 (** JSON oui config file positional argument, sits as first positional arg. *)
@@ -92,3 +93,10 @@ val tar_extra : string list option Cmdliner.Term.t
 val macos_application_signing_id : string option Cmdliner.Term.t
 
 val macos_application_signing_id_abstract : string option abstract
+
+(** --macos-installer-signing-id option to pass Developer ID Installer
+    certificate name to productbuild for .pkg signature. Overrides the JSON
+    config field. *)
+val macos_installer_signing_id : string option Cmdliner.Term.t
+
+val macos_installer_signing_id_abstract : string option abstract

--- a/src/oui_lib/installer_config.ml
+++ b/src/oui_lib/installer_config.ml
@@ -105,6 +105,7 @@ type ('manpages, 'env_val) t = {
     wix_license_file : string option; [@default None]
     macos_symlink_dirs : string list; [@default []]
     macos_application_signing_id: string option; [@default None]
+    macos_installer_signing_id: string option; [@default None]
   }
 [@@deriving yojson {meta = true}]
 

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -90,6 +90,9 @@ type ('manpages, 'string_with_vars) t = {
     macos_application_signing_id: string option;
     (** Developer ID Application certificate, passed to codesign to sign
         binaries *)
+    macos_installer_signing_id: string option;
+    (** Developer ID Installer certificate, passed to productbuild to sign
+        .pkg *)
   }
 
 type user = (manpages, String_with_vars.t) t

--- a/src/oui_lib/opam_frontend.ml
+++ b/src/oui_lib/opam_frontend.ml
@@ -387,6 +387,7 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
      wix_license_file = None; (* TODO *)
      macos_symlink_dirs = []; (* TODO *)
      macos_application_signing_id = None;
+     macos_installer_signing_id = None;
    })
 
 let with_opam_and_conf ~conf_file cli global_options f =

--- a/src/oui_lib/pkgbuild_backend.ml
+++ b/src/oui_lib/pkgbuild_backend.ml
@@ -202,9 +202,15 @@ let create_installer
   System.call_unit System.Pkgbuild pkgbuild_args;
 
   OpamConsole.msg "Creating final installer package...\n";
+  let sign =
+    Option.map
+      (fun x -> {System.identity = x; timestamp = true})
+      installer_config.macos_installer_signing_id
+  in
   let productbuild_args : System.productbuild_args = {
     package = component_pkg_path;
     output = installer;
+    sign;
   } in
   System.call_unit System.Productbuild productbuild_args;
 

--- a/src/oui_lib/system.ml
+++ b/src/oui_lib/system.ml
@@ -52,9 +52,15 @@ type pkgbuild_args = {
   output : OpamFilename.t;
 }
 
+type productbuild_sign_args = {
+  identity : string;
+  timestamp : bool;
+}
+
 type productbuild_args = {
   package : OpamFilename.t;
   output : OpamFilename.t;
+  sign : productbuild_sign_args option;
 }
 
 type touch_args = {
@@ -151,8 +157,17 @@ let call_inner : type a. a command -> a -> string * string list =
       | None -> args
     in
     "pkgbuild", args @ [ OpamFilename.to_string output ]
-  | Productbuild, { package; output } ->
-    "productbuild", [
+  | Productbuild, { package; output; sign } ->
+    let sign_args =
+      match sign with
+      | None -> []
+      | Some {identity; timestamp} ->
+        let sign = ["--sign"; identity] in
+        if timestamp then "--timestamp"::sign else sign
+    in
+    "productbuild",
+    sign_args @
+    [
       "--package"; OpamFilename.to_string package;
       OpamFilename.to_string output
     ]

--- a/src/oui_lib/system.mli
+++ b/src/oui_lib/system.mli
@@ -69,10 +69,16 @@ type pkgbuild_args = {
   output : OpamFilename.t; (** Output .pkg file *)
 }
 
+type productbuild_sign_args = {
+  identity : string;
+  timestamp : bool;
+}
+
 (** Arguments for productbuild command *)
 type productbuild_args = {
   package : OpamFilename.t; (** Component package to wrap *)
   output : OpamFilename.t; (** Output .pkg file *)
+  sign: productbuild_sign_args option; (** Whether to sign the .pkg and how *)
 }
 
 (** Arguments for patchelf command *)

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -61,6 +61,7 @@ let make_config
   ; wix_license_file = None
   ; macos_symlink_dirs = []
   ; macos_application_signing_id = None
+  ; macos_installer_signing_id = None
   }
 
 let pp_sh = Sh_script.pp_sh ~version:false


### PR DESCRIPTION
This is based on #147.

This is the second and final step towards fixing #143.

It's now possible to get `oui` to sign the generated `.pkg` installer on MacOS by providing a Developer ID certificate (or  the Common Name of any certificate available in the keychain, note that only Apple issued developer IDs are recognized by Gatekeeper though).
It can be provided via a JSON config field or CLI option. When missing, the .pkg is left unsigned as it is the case prior to this PR.