### PR TITLE
Use LoadLibrary and GetModuleFilename to retrieve dll paths

### DIFF
--- a/src/oui_lib/win_ldd.ml
+++ b/src/oui_lib/win_ldd.ml
@@ -201,7 +201,7 @@ let is_system32 =
     | _ -> false
 
 (* Note: string is encoded using the current Windows ANSI encoding, not UTF-8 *)
-external resolve_dll : string -> string option = "ml_resolve_dll"
+external resolve_dll : string -> (string, string) result = "ml_resolve_dll"
 
 let get_dlls binary =
   let rec aux dlls binary =
@@ -209,8 +209,10 @@ let get_dlls binary =
     let new_dlls =
       List.filter_map (fun dll ->
           match resolve_dll dll with
-          | None -> None (* Maybe should warn ? *)
-          | Some (dll) ->
+          | Error e ->
+              OpamConsole.warning "%s" e;
+              None
+          | Ok dll ->
               if is_system32 dll then None
               else if StrSet.mem dll dlls then None
               else Some (dll)

--- a/src/oui_lib/win_ldd.ml
+++ b/src/oui_lib/win_ldd.ml
@@ -210,7 +210,8 @@ let get_dlls binary =
       List.filter_map (fun dll ->
           match resolve_dll dll with
           | Error e ->
-              OpamConsole.warning "%s" e;
+              OpamConsole.warning
+                "Error while listing %s dll dependencies: %s" binary e;
               None
           | Ok dll ->
               if is_system32 dll then None

--- a/src/oui_lib/win_ldd.ml
+++ b/src/oui_lib/win_ldd.ml
@@ -211,7 +211,7 @@ let get_dlls binary =
           match resolve_dll dll with
           | Error e ->
               OpamConsole.warning
-                "Error while listing %s dll dependencies: %s" binary e;
+                "Error while listing %s DLL dependencies: %s" binary e;
               None
           | Ok dll ->
               if is_system32 dll then None

--- a/src/oui_lib/win_ldd_c.c
+++ b/src/oui_lib/win_ldd_c.c
@@ -93,7 +93,7 @@ CAMLprim value ml_resolve_dll(value mlDllName)
   }
 
   mlTmp = ml_wchar_to_value(filename, CP_UTF8);
-  mlResult = caml_alloc_some(mlTmp);
+  mlResult = caml_alloc_ok(mlTmp);
 
 exit:
   FreeLibrary(hm);

--- a/src/oui_lib/win_ldd_c.c
+++ b/src/oui_lib/win_ldd_c.c
@@ -1,5 +1,6 @@
 
 #include <stdlib.h>
+#include <stdarg.h>
 #include <wchar.h>
 
 #include <caml/mlvalues.h>
@@ -43,19 +44,59 @@ WCHAR * ml_value_to_wchar(value mlString, UINT codepage)
   CAMLreturnT(WCHAR *, result);
 }
 
+static value caml_alloc_ok(value mlPayload) {
+  CAMLparam1(mlPayload);
+  CAMLlocal1(mlResult);
+  mlResult = caml_alloc(1, 0);
+  Field(mlResult, 0) = mlPayload;
+  CAMLreturn(mlResult);
+}
+
+static value caml_alloc_error(value mlPayload) {
+  CAMLparam1(mlPayload);
+  CAMLlocal1(mlResult);
+  mlResult = caml_alloc(1, 1);
+  Field(mlResult, 0) = mlPayload;
+  CAMLreturn(mlResult);
+}
+
+#define BUF_SIZE 4096
+
+static value alloc_error(const char *restrict fmt, ...) {
+  CAMLparam0();
+  va_list ap;
+  va_start(ap, fmt);
+  const char buf[BUF_SIZE] = {0};
+  vsnprintf(buf, BUF_SIZE, fmt, ap);
+  va_end(ap);
+  CAMLreturn(caml_alloc_error(caml_copy_string(buf)));
+}
+
 CAMLprim value ml_resolve_dll(value mlDllName)
 {
   CAMLparam1(mlDllName);
   CAMLlocal2(mlResult, mlTmp);
   WCHAR *dllname = ml_value_to_wchar(mlDllName, CP_ACP);
   WCHAR filename[MAX_PATH];
-  DWORD len = SearchPathW(NULL, dllname, NULL, MAX_PATH, filename, NULL);
-  if (len > 0 && len < MAX_PATH) {
-    mlTmp = ml_wchar_to_value(filename, CP_UTF8);
-    mlResult = caml_alloc_some(mlTmp);
-  } else {
-    mlResult = Val_none;
+
+  HMODULE hm = LoadLibraryExW(dllname, NULL, DONT_RESOLVE_DLL_REFERENCES);
+  if (hm == NULL) {
+    mlResult = alloc_error("cannot load the library with error code %ld", GetLastError());
+    goto exit;
   }
+
+  DWORD len = GetModuleFileNameW(hm, filename, MAX_PATH);
+  if (len <= 0 || len >= MAX_PATH) {
+    mlResult = alloc_error("cannot retrieve the path of the dll %ls with error code %ld",
+        filename, GetLastError());
+    goto exit;
+  }
+
+  mlTmp = ml_wchar_to_value(filename, CP_UTF8);
+  mlResult = caml_alloc_some(mlTmp);
+
+exit:
+  FreeLibrary(hm);
   free(dllname);
   CAMLreturn(mlResult);
 }

--- a/src/oui_lib/win_ldd_c.c
+++ b/src/oui_lib/win_ldd_c.c
@@ -98,7 +98,7 @@ CAMLprim value ml_resolve_dll(value mlDllName)
 
   DWORD len = GetModuleFileNameW(hm, filename, MAX_PATH);
   if (len <= 0 || len >= MAX_PATH) {
-    mlResult = alloc_error("cannot retrieve the path of the dll %ls with error code %ld",
+    mlResult = alloc_error("cannot retrieve the path of the DLL %ls with error code %ld",
         filename, GetLastError());
     goto exit;
   }

--- a/src/oui_lib/win_ldd_c.c
+++ b/src/oui_lib/win_ldd_c.c
@@ -79,6 +79,17 @@ CAMLprim value ml_resolve_dll(value mlDllName)
   WCHAR *dllname = ml_value_to_wchar(mlDllName, CP_ACP);
   WCHAR filename[MAX_PATH];
 
+  // The only reliable way to retrieve the full path of a DLL is to load it.
+  //
+  // The flag `DONT_RESOLVE_DLL_REFERENCES` prevents `LoadLibraryExW` from
+  // loading extra modules or running initialization code of the library.
+  //
+  // In particular, this function cannot discover the DLL paths of transitive
+  // dependencies that are not direct dependencies.
+  //
+  // Although this flag is deprecated, the new flag
+  // `LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE` or `LOAD_LIBRARY_AS_IMAGE_RESOURCE`
+  // don't allow requesting the full path of the DLL with `GetModuleFileNameW`.
   HMODULE hm = LoadLibraryExW(dllname, NULL, DONT_RESOLVE_DLL_REFERENCES);
   if (hm == NULL) {
     mlResult = alloc_error("cannot load the library with error code %ld", GetLastError());


### PR DESCRIPTION
This PR fixes the issue 131. The previous code used `SearchPath` to retrieve the paths of dlls by their name but this function didn't search files in the same order as `LoadLibrary`.

The new strategy consists in loading the dll with `LoadLibraryExW` with the `DONT_RESOLVE_DLL_REFERENCES` flag. This flag ensures that the main function of the module is not called.

The new code displays warnings if this approach failed for some dlls.