### PR TITLE
Support multiple binary symbolic links on macOS

### DIFF
--- a/src/oui_lib/macos_postinstall.ml
+++ b/src/oui_lib/macos_postinstall.ml
@@ -31,35 +31,37 @@ load_conf() {
 }
 |}
 
-let generate_wrapper_section ~app_path ~binary_name ~has_binary ~env =
-  if not has_binary then
-    "# Plugin-only package - no wrapper script"
-  else
-    let wrapper_content =
-      let env_lines =
-        List.map
-          (fun (var, value) ->
-             (* VAR="VALUE" \ *)
-             Printf.sprintf "%s=\"%s\" \\\\" var value)
-          env
-      in
-      String.concat "\n"
-        ( "#!/bin/bash"
-          :: env_lines
-          @ [ Printf.sprintf {|exec "%s/Contents/MacOS/%s" "$@"|}
-                app_path binary_name ] )
+let binary_name binary = Filename.basename binary.Installer_config.path
+let pp_newline ppf () = Format.fprintf ppf "\n"
+let pp_string ppf = Format.fprintf ppf "%s"
+
+let generate_wrapper_section ~app_path ~binary ~env =
+  let binary_name = binary_name binary in
+  let wrapper_content =
+    let env_lines =
+      List.map
+        (fun (var, value) ->
+           (* VAR="VALUE" \ *)
+           Printf.sprintf "%s=\"%s\" \\\\" var value)
+        env
     in
-    let wrapper_creation =
-      Printf.sprintf {|cat > "/usr/local/bin/%s" << 'WRAPPER_EOF'
+    String.concat "\n"
+      ( "#!/bin/bash"
+        :: env_lines
+        @ [ Printf.sprintf {|exec "%s/Contents/Resources/%s" "$@"|}
+              app_path binary.path ] )
+  in
+  let wrapper_creation =
+    Printf.sprintf {|cat > "/usr/local/bin/%s" << 'WRAPPER_EOF'
 %s
 WRAPPER_EOF|}
-        binary_name wrapper_content
-    in
-    let wrapper_chmod =
-      Printf.sprintf "chmod +x \"/usr/local/bin/%s\"" binary_name
-    in
-    Printf.sprintf "mkdir -p /usr/local/bin\n\n%s\n%s"
-      wrapper_creation wrapper_chmod
+      binary_name wrapper_content
+  in
+  let wrapper_chmod =
+    Printf.sprintf "chmod +x \"/usr/local/bin/%s\"" binary_name
+  in
+  Printf.sprintf "mkdir -p /usr/local/bin\n\n%s\n%s"
+    wrapper_creation wrapper_chmod
 
 let generate_load_app_conf ~target_app =
   let capitalized = String.capitalize_ascii target_app in
@@ -137,37 +139,40 @@ fi|}
 let generate_postinstall_script
     ~env
     ~app_name
-    ~binary_name
-    ~has_binary
+    ~binaries
     ?(plugins : Installer_config.plugin list = [])
     () =
   let app_path = Printf.sprintf "/Applications/%s.app" app_name in
   let resources = Printf.sprintf "%s/Contents/Resources" app_path in
 
   let def_install_path = Printf.sprintf "INSTALL_PATH=%s" resources in
-  let wrapper_section =
-    generate_wrapper_section ~app_path ~binary_name ~has_binary ~env
+  let wrapper_sections =
+    List.filter_map (fun binary ->
+      if binary.Installer_config.symlink then
+        Some (generate_wrapper_section ~app_path ~binary ~env)
+      else
+        None) binaries
   in
   let plugin_install_section =
     generate_plugin_install_section ~resources ~plugins
   in
   let manpages_section = generate_manpages_section ~resources in
 
-  Printf.sprintf {|#!/bin/bash
+  Format.asprintf {|#!/bin/bash
 set -e
 
 %s
-%s
+%a
 
 %s
 %s
 exit 0|}
     def_install_path
-    wrapper_section
+    (Format.pp_print_list ~pp_sep:pp_newline pp_string) wrapper_sections
     plugin_install_section
     manpages_section
 
-let generate_uninstall_script ~app_name ~binary_name ~has_binary ~plugins
+let generate_uninstall_script ~app_name ~binaries ~plugins
   ~app_uid =
   let app_path = Printf.sprintf "/Applications/%s.app" app_name in
   let resources = Printf.sprintf "%s/Contents/Resources" app_path in
@@ -213,24 +218,29 @@ rm -f "${%slib}/%s" 2>/dev/null || true
       load_and_remove ^ remove_symlinks
   in
 
-  let wrapper_removal =
-    if has_binary then
-      Printf.sprintf {|# Remove wrapper from /usr/local/bin
+  let wrapper_removals =
+    List.filter_map (fun binary ->
+      if binary.Installer_config.symlink then
+      let binary_name = binary_name binary in
+      let s =
+        Format.asprintf {|# Remove wrapper from /usr/local/bin
 if [ -L "/usr/local/bin/%s" ] || [ -f "/usr/local/bin/%s" ]; then
   echo "Removing /usr/local/bin/%s"
   rm -f "/usr/local/bin/%s"
 fi|}
-        binary_name binary_name binary_name binary_name
+          binary_name binary_name binary_name binary_name
+      in
+      Some s
     else
-      "# Plugin-only package - no wrapper to remove"
+      None) binaries
   in
 
-  Printf.sprintf {|#!/bin/bash
+  Format.asprintf {|#!/bin/bash
 set -e
 
 echo "Uninstalling %s..."
 %s
-%s
+%a
 
 # Remove manpage symlinks
 find /usr/local/share/man -type l -lname "%s/*" -delete 2>/dev/null || true
@@ -248,7 +258,7 @@ echo "Uninstallation complete!"
 |}
     app_name
     plugin_removal
-    wrapper_removal
+    (Format.pp_print_list ~pp_sep:pp_newline pp_string) wrapper_removals
     resources
     app_path app_path app_path
     app_uid

--- a/src/oui_lib/macos_postinstall.mli
+++ b/src/oui_lib/macos_postinstall.mli
@@ -18,8 +18,7 @@
 val generate_postinstall_script :
   env:(string * string) list ->
   app_name:string ->
-  binary_name:string ->
-  has_binary:bool ->
+  binaries:Installer_config.exec_file list ->
   ?plugins:Installer_config.plugin list ->
   unit ->
   string
@@ -35,8 +34,7 @@ val generate_postinstall_script :
 *)
 val generate_uninstall_script :
   app_name:string ->
-  binary_name:string ->
-  has_binary:bool ->
+  binaries:Installer_config.exec_file list ->
   plugins:Installer_config.plugin list ->
   app_uid:string ->
   string

--- a/src/oui_lib/pkgbuild_backend.ml
+++ b/src/oui_lib/pkgbuild_backend.ml
@@ -103,11 +103,10 @@ let create_installer
   Macos_app_bundle.copy_bundle_contents bundle ~bundle_dir;
 
   (* Install main binary to MacOS directory (if exec_files provided) *)
-  let binary_name = match installer_config.exec_files with
+  let () = match installer_config.exec_files with
     | [] ->
       (* Plugin-only bundle - no main binary *)
-      OpamConsole.msg "No exec_files specified, creating plugin-only package\n";
-      None
+      OpamConsole.msg "No exec_files specified, creating plugin-only package\n"
     | binary :: _ ->
       let binary_src = bundle_dir // binary.path in
       let binary_dst =
@@ -122,8 +121,7 @@ let create_installer
       (match installer_config.macos_application_signing_id with
        | None -> Codesign.sign_binary_adhoc binary_dst
        | Some cert_name ->
-         Codesign.sign_binary_with_dev_id ~cert_name binary_dst);
-      Some bundle.binary_name
+         Codesign.sign_binary_with_dev_id ~cert_name binary_dst)
   in
 
   create_info_plist bundle ~installer_config;
@@ -152,16 +150,10 @@ let create_installer
 
   (* Create postinstall script *)
   let scripts_dir = work_dir / "scripts" in
-  let has_binary = Option.is_some binary_name in
-  let binary_name_for_scripts = match binary_name with
-    | Some n -> n
-    | None -> installer_config.name
-  in
   let postinstall_content = Macos_postinstall.generate_postinstall_script
       ~env:installer_config.environment
       ~app_name:bundle.app_name
-      ~binary_name:binary_name_for_scripts
-      ~has_binary
+      ~binaries:installer_config.exec_files
       ~plugins:installer_config.plugins
       ()
   in
@@ -173,8 +165,7 @@ let create_installer
   (* Create uninstall script in bundle *)
   let uninstall_content = Macos_postinstall.generate_uninstall_script
       ~app_name:bundle.app_name
-      ~binary_name:binary_name_for_scripts
-      ~has_binary
+      ~binaries:installer_config.exec_files
       ~plugins:installer_config.plugins
       ~app_uid:bundle.bundle_id
   in

--- a/tests/oui_lib/dune
+++ b/tests/oui_lib/dune
@@ -29,7 +29,7 @@
 (library
  (name macos_tests)
  (inline_tests)
- (modules test_otool test_plist)
+ (modules test_otool test_plist test_pkgbuild_backend)
  (enabled_if
   (= %{system} "macosx"))
  (preprocess

--- a/tests/oui_lib/test_pkgbuild_backend.ml
+++ b/tests/oui_lib/test_pkgbuild_backend.ml
@@ -1,0 +1,180 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2026 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Oui
+open Installer_config
+
+(* FIXME: copy-past of the same function from `test_makeself_backend`. *)
+let pp_sh = Sh_script.pp_sh ~version:false
+
+(* FIXME: copy-past of the same function from `test_makeself_backend`. *)
+let make_expanded_manpages
+    ?(man1=[])
+    ?(man2=[])
+    ?(man3=[])
+    ?(man4=[])
+    ?(man5=[])
+    ?(man6=[])
+    ?(man7=[])
+    ?(man8=[])
+    ()
+  =
+  [ ("man1", man1)
+  ; ("man2", man2)
+  ; ("man3", man3)
+  ; ("man4", man4)
+  ; ("man5", man5)
+  ; ("man6", man6)
+  ; ("man7", man7)
+  ; ("man8", man8)
+  ]
+  |> List.filter_map (function _, [] -> None | x -> Some x)
+
+(* FIXME: copy-past of the same function from `test_makeself_backend`. *)
+let make_config
+    ?(name="test-name")
+    ?(version="test.version")
+    ?(exec_files=[])
+    ?(plugins=[])
+    ?plugin_dirs
+    ?manpages
+    ?(environment=[])
+    () : Installer_config.internal
+  =
+  { name
+  ; version
+  ; exec_files
+  ; fullname = ""
+  ; manpages
+  ; environment
+  ; unique_id = ""
+  ; plugins
+  ; plugin_dirs
+  ; wix_manufacturer = ""
+  ; wix_description = None
+  ; wix_tags = []
+  ; wix_icon_file = None
+  ; wix_dlg_bmp_file = None
+  ; wix_banner_bmp_file = None
+  ; wix_license_file = None
+  ; macos_symlink_dirs = []
+  ; macos_application_signing_id = None
+  }
+
+let%expect_test "postinstall_script" =
+  let manpages =
+    make_expanded_manpages
+      ~man1:["man/man1/aaa-command.1"; "man/man1/aaa-utility.1"]
+      ~man5:["man/man5/aaa-file.1"]
+      ()
+  in
+  let config =
+    make_config ~name:"aaa" ~version:"x.y.z"
+      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
+                   { path = "aaa-utility"; symlink = true; deps = true } ]
+      ~manpages
+      ()
+  in
+  let app_name = "aaa" in
+  let env = [] in
+  let s =
+    Macos_postinstall.generate_postinstall_script ~env ~app_name
+      ~binaries:config.exec_files ()
+  in
+  Format.printf "%s" s;
+  [%expect {|
+    #!/bin/bash
+    set -e
+
+    INSTALL_PATH=/Applications/aaa.app/Contents/Resources
+    mkdir -p /usr/local/bin
+
+    cat > "/usr/local/bin/aaa-command" << 'WRAPPER_EOF'
+    #!/bin/bash
+    exec "/Applications/aaa.app/Contents/Resources/aaa-command" "$@"
+    WRAPPER_EOF
+    chmod +x "/usr/local/bin/aaa-command"
+    mkdir -p /usr/local/bin
+
+    cat > "/usr/local/bin/aaa-utility" << 'WRAPPER_EOF'
+    #!/bin/bash
+    exec "/Applications/aaa.app/Contents/Resources/aaa-utility" "$@"
+    WRAPPER_EOF
+    chmod +x "/usr/local/bin/aaa-utility"
+
+
+    if [ -d "/Applications/aaa.app/Contents/Resources/man" ]; then
+      mkdir -p /usr/local/share/man
+      for section_dir in /Applications/aaa.app/Contents/Resources/man/*; do
+        if [ -d "$section_dir" ]; then
+          section=$(basename "$section_dir")
+          mkdir -p /usr/local/share/man/${section}
+          for manpage in "$section_dir"/*; do
+            [ -f "$manpage" ] && ln -sf "$manpage" "/usr/local/share/man/${section}/$(basename "$manpage")"
+          done
+        fi
+      done
+    fi
+    exit 0
+    |}]
+
+let%expect_test "uninstall_script" =
+  let manpages =
+    make_expanded_manpages
+      ~man1:["man/man1/aaa-command.1"; "man/man1/aaa-utility.1"]
+      ~man5:["man/man5/aaa-file.1"]
+      ()
+  in
+  let config =
+    make_config ~name:"aaa" ~version:"x.y.z"
+      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
+                   { path = "aaa-utility"; symlink = true; deps = true } ]
+      ~manpages
+      ()
+  in
+  let app_name = "aaa" in
+  let app_uid = "aaa-uid" in
+  let plugins = [] in
+  let s =
+    Macos_postinstall.generate_uninstall_script ~app_name
+      ~binaries:config.exec_files ~plugins ~app_uid
+  in
+  Format.printf "%s" s;
+  [%expect {|
+    #!/bin/bash
+    set -e
+
+    echo "Uninstalling aaa..."
+
+    # Remove wrapper from /usr/local/bin
+    if [ -L "/usr/local/bin/aaa-command" ] || [ -f "/usr/local/bin/aaa-command" ]; then
+      echo "Removing /usr/local/bin/aaa-command"
+      rm -f "/usr/local/bin/aaa-command"
+    fi
+    # Remove wrapper from /usr/local/bin
+    if [ -L "/usr/local/bin/aaa-utility" ] || [ -f "/usr/local/bin/aaa-utility" ]; then
+      echo "Removing /usr/local/bin/aaa-utility"
+      rm -f "/usr/local/bin/aaa-utility"
+    fi
+
+    # Remove manpage symlinks
+    find /usr/local/share/man -type l -lname "/Applications/aaa.app/Contents/Resources/*" -delete 2>/dev/null || true
+
+    # Remove the app bundle
+    if [ -d "/Applications/aaa.app" ]; then
+      echo "Removing /Applications/aaa.app"
+      rm -rf "/Applications/aaa.app"
+    fi
+
+    # Remove MacOs package receipt
+    pkgutil --forget "aaa-uid"
+
+    echo "Uninstallation complete!"
+    |}]


### PR DESCRIPTION
On Linux, a symbolic link per binary is generated. On macOS, such a link was only generated for the main binary of the bundle (the binary located in `Contents/MacOS`).

This PR changes the post-install script on macOS. Now, we generate a symbolic link for each public binaries of the bundle if the `symlink` flag is `true`, which is the default.