### PR TITLE
Fix frama-c CI tests

### DIFF
--- a/.github/scripts/test-frama-c-plugin.sh
+++ b/.github/scripts/test-frama-c-plugin.sh
@@ -56,7 +56,7 @@ cat > "$FRAMA_C_BUNDLE/oui.json" << EOF
   "fullname": "Frama-C",
   "version": "32.0",
   "unique_id": "$FRAMA_C_UID",
-  "exec_files": ["bin/frama-c", "bin/frama-c-config", "bin/frama-c-script"],
+  "exec_files": ["bin/frama-c"],
   "wix_manufacturer": "CEA LIST",
   "plugin_dirs": { "plugins_dir": "lib/frama-c/plugins", "lib_dir": "lib" },
   "macos_symlink_dirs": ["lib", "share"],

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,4 +38,6 @@ jobs:
         run: bash .github/scripts/test-alt-ergo.sh macos
 
       - name: Test frama-c and plugin support
+        # Latest frama-c does not build with 4.14
+        if: ${{ matrix.ocaml-compiler == 5.2.x}}
         run: bash .github/scripts/test-frama-c-plugin.sh


### PR DESCRIPTION
The latest version of frama-c removed some scripts which were still referenced from our `oui.json` files and triggered failures.